### PR TITLE
Add visualization route for convex problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,13 @@ x >= 0
 y >= 0
 ```
 
-### 3. Educational Content
+### 3. Visualization Tool
+
+The visualization tool generates 2D plots of the feasible region and contour lines for small two-variable problems. You can optionally animate gradient descent to illustrate convergence.
+
+Navigate to `/visualize` to try it out.
+
+### 4. Educational Content
 
 The app provides educational content on:
 - The basics of convex optimization

--- a/app.py
+++ b/app.py
@@ -1,11 +1,18 @@
 from fastapi import FastAPI, Request, Form
 from fastapi.templating import Jinja2Templates
 from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 import uvicorn
 import pulp
 import cvxpy as cp
 import re
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from io import BytesIO
+import base64
 
 app = FastAPI()
 templates = Jinja2Templates(directory="templates")
@@ -22,6 +29,39 @@ def parse_expression(expr):
     expr = expr.replace(' ', '')  # Remove all spaces
     terms = re.findall(r'([+-]?(?:\d*\.)?\d*)([a-zA-Z]\w*(?:\^2)?)', expr)
     return [(float(coef) if coef and coef not in ['+', '-'] else (1.0 if coef != '-' else -1.0), var) for coef, var in terms if var]
+
+def evaluate_expression(terms, x, y):
+    result = np.zeros_like(x, dtype=float)
+    for coef, var in terms:
+        if '^2' in var:
+            base = var.split('^')[0]
+            if base == 'x':
+                result += coef * x**2
+            elif base == 'y':
+                result += coef * y**2
+        else:
+            if var == 'x':
+                result += coef * x
+            elif var == 'y':
+                result += coef * y
+    return result
+
+def gradient(terms, point):
+    grad = np.zeros(2)
+    x, y = point
+    for coef, var in terms:
+        if '^2' in var:
+            base = var.split('^')[0]
+            if base == 'x':
+                grad[0] += 2 * coef * x
+            elif base == 'y':
+                grad[1] += 2 * coef * y
+        else:
+            if var == 'x':
+                grad[0] += coef
+            elif var == 'y':
+                grad[1] += coef
+    return grad
 
 @app.get("/", response_class=HTMLResponse)
 async def root(request: Request):
@@ -134,6 +174,82 @@ async def quadratic_program_post(request: Request, objective: str = Form(...), c
         result = f"An error occurred: {str(e)}"
 
     return templates.TemplateResponse("quadratic_program.html", {"request": request, "result": result})
+
+@app.get("/visualize", response_class=HTMLResponse)
+async def visualize_get(request: Request):
+    return templates.TemplateResponse("visualize.html", {"request": request})
+
+@app.post("/visualize", response_class=HTMLResponse)
+async def visualize_post(request: Request, objective: str = Form(...), constraints: str = Form(...), animate: str = Form(None)):
+    try:
+        obj_terms = parse_expression(objective)
+
+        x = np.linspace(-5, 5, 200)
+        y = np.linspace(-5, 5, 200)
+        X, Y = np.meshgrid(x, y)
+
+        Z = evaluate_expression(obj_terms, X, Y)
+
+        mask = np.ones_like(X, dtype=bool)
+        for cons in constraints.split('\n'):
+            if cons.strip():
+                if '<=' in cons:
+                    lhs, rhs = cons.split('<=')
+                    lhs_terms = parse_expression(lhs)
+                    lhs_val = evaluate_expression(lhs_terms, X, Y)
+                    mask &= lhs_val <= float(rhs.strip())
+                elif '>=' in cons:
+                    lhs, rhs = cons.split('>=')
+                    lhs_terms = parse_expression(lhs)
+                    lhs_val = evaluate_expression(lhs_terms, X, Y)
+                    mask &= lhs_val >= float(rhs.strip())
+
+        fig, ax = plt.subplots()
+        ax.set_xlabel('x')
+        ax.set_ylabel('y')
+        ax.contour(X, Y, Z, levels=20, cmap='viridis')
+        ax.contourf(X, Y, mask, levels=[0.5, 1], colors=['#d0f0d0'], alpha=0.3)
+
+        plot_buffer = BytesIO()
+        fig.savefig(plot_buffer, format='png')
+        plt.close(fig)
+        plot_data = base64.b64encode(plot_buffer.getvalue()).decode('utf-8')
+
+        animation_data = None
+        if animate:
+            point = np.array([4.0, 4.0])
+            path = [point.copy()]
+            lr = 0.1
+            for _ in range(30):
+                g = gradient(obj_terms, point)
+                point = point - lr * g
+                path.append(point.copy())
+
+            fig_anim, ax_anim = plt.subplots()
+            ax_anim.contour(X, Y, Z, levels=20, cmap='viridis')
+            ax_anim.contourf(X, Y, mask, levels=[0.5, 1], colors=['#d0f0d0'], alpha=0.3)
+            path = np.array(path)
+            ax_anim.plot(path[:,0], path[:,1], marker='o', color='red')
+            anim_buffer = BytesIO()
+            fig_anim.savefig(anim_buffer, format='png')
+            plt.close(fig_anim)
+            animation_data = base64.b64encode(anim_buffer.getvalue()).decode('utf-8')
+
+        result = None
+    except Exception as e:
+        plot_data = None
+        animation_data = None
+        result = f"An error occurred: {str(e)}"
+
+    return templates.TemplateResponse(
+        "visualize.html",
+        {
+            "request": request,
+            "plot_data": plot_data,
+            "animation_data": animation_data,
+            "result": result,
+        },
+    )
 
 if __name__ == "__main__":
     uvicorn.run("app:app", host="0.0.0.0", port=8000, reload=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,6 +36,8 @@
         <p>Solve optimization problems with linear objective functions and linear constraints.</p>
         <a href="/quadratic_program" class="problem-link">Quadratic Programming</a>
         <p>Tackle problems with quadratic objective functions and linear constraints.</p>
+        <a href="/visualize" class="problem-link">Visualization Tool</a>
+        <p>Plot feasible regions and objective contours for small problems.</p>
     </section>
 </body>
 </html>

--- a/templates/visualize.html
+++ b/templates/visualize.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Visualization - Convex Optimization App</title>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; line-height: 1.6; padding: 20px; max-width: 800px; margin: 0 auto; }
+        h1, h2 { color: #333; }
+        form { background-color: #f0f0f0; padding: 20px; border-radius: 5px; }
+        label { display: block; margin-bottom: 5px; }
+        input[type="text"], textarea { width: 100%; padding: 8px; margin-bottom: 10px; border: 1px solid #ddd; border-radius: 4px; }
+        input[type="submit"] { background-color: #4CAF50; color: white; padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer; }
+        input[type="submit"]:hover { background-color: #45a049; }
+        #plot { margin-top: 20px; }
+    </style>
+</head>
+<body>
+    <h1>Visualization</h1>
+    <form action="/visualize" method="post">
+        <label for="objective">Objective Function:</label>
+        <input type="text" id="objective" name="objective" required placeholder="e.g., 3x + 2y">
+
+        <label for="constraints">Constraints (one per line):</label>
+        <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., x + y <= 10&#10;x >= 0&#10;y >= 0"></textarea>
+
+        <label><input type="checkbox" name="animate" value="true"> Animate Gradient Descent</label>
+
+        <input type="submit" value="Visualize">
+    </form>
+
+    {% if plot_data %}
+    <div id="plot">
+        <h2>Visualization:</h2>
+        <img src="data:image/png;base64,{{ plot_data }}" alt="Visualization Plot">
+    </div>
+    {% endif %}
+
+    {% if animation_data %}
+    <div id="animation">
+        <h2>Algorithm Progress:</h2>
+        <img src="data:image/gif;base64,{{ animation_data }}" alt="Algorithm Animation">
+    </div>
+    {% endif %}
+
+    <p><a href="/">Back to Home</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce `/visualize` route for plotting convex problem geometry
- support optional gradient descent path animation
- link to the visualization tool on the home page
- document visualization in README

## Testing
- `python -m py_compile app.py`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6845dc496824832a92dfec7f432c4d2d