### PR TITLE
Refactor routes and add solvers module

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,139 +1,22 @@
-from fastapi import FastAPI, Request, Form
-from fastapi.templating import Jinja2Templates
-from fastapi.responses import HTMLResponse
-from pydantic import BaseModel
-import uvicorn
-import pulp
-import cvxpy as cp
-import re
+"""FastAPI application setup."""
 
-app = FastAPI()
-templates = Jinja2Templates(directory="templates")
+from __future__ import annotations
 
-class LinearProgramInput(BaseModel):
-    objective: str
-    constraints: str
+from fastapi import FastAPI
 
-class QuadraticProgramInput(BaseModel):
-    objective: str
-    constraints: str
+from routes import router
 
-def parse_expression(expr):
-    expr = expr.replace(' ', '')  # Remove all spaces
-    terms = re.findall(r'([+-]?(?:\d*\.)?\d*)([a-zA-Z]\w*(?:\^2)?)', expr)
-    return [(float(coef) if coef and coef not in ['+', '-'] else (1.0 if coef != '-' else -1.0), var) for coef, var in terms if var]
 
-@app.get("/", response_class=HTMLResponse)
-async def root(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application."""
+    application = FastAPI()
+    application.include_router(router)
+    return application
 
-@app.get("/linear_program", response_class=HTMLResponse)
-async def linear_program_get(request: Request):
-    return templates.TemplateResponse("linear_program.html", {"request": request})
 
-@app.post("/linear_program", response_class=HTMLResponse)
-async def linear_program_post(request: Request, objective: str = Form(...), constraints: str = Form(...)):
-    try:
-        # Create a PuLP problem
-        prob = pulp.LpProblem("Linear Program", pulp.LpMinimize)
-
-        # Parse objective function
-        obj_terms = parse_expression(objective)
-        variables = {var: pulp.LpVariable(var) for _, var in obj_terms}
-        
-        # Set objective
-        prob += pulp.lpSum(coef * variables[var] for coef, var in obj_terms)
-
-        # Parse and add constraints
-        for constraint in constraints.split('\n'):
-            if constraint.strip():
-                if '<=' in constraint:
-                    lhs, rhs = constraint.split('<=')
-                    lhs_terms = parse_expression(lhs)
-                    prob += pulp.lpSum(coef * variables[var] for coef, var in lhs_terms) <= float(rhs.strip())
-                elif '>=' in constraint:
-                    lhs, rhs = constraint.split('>=')
-                    lhs_terms = parse_expression(lhs)
-                    prob += pulp.lpSum(coef * variables[var] for coef, var in lhs_terms) >= float(rhs.strip())
-
-        # Solve the problem
-        prob.solve()
-
-        # Prepare the result
-        status = pulp.LpStatus[prob.status]
-        if status == "Optimal":
-            result = f"Status: {status}\n"
-            for var in prob.variables():
-                result += f"{var.name} = {var.varValue}\n"
-            result += f"Objective value: {pulp.value(prob.objective)}"
-        else:
-            result = f"Status: {status}"
-
-    except Exception as e:
-        result = f"An error occurred: {str(e)}"
-
-    return templates.TemplateResponse("linear_program.html", {"request": request, "result": result})
-
-@app.get("/quadratic_program", response_class=HTMLResponse)
-async def quadratic_program_get(request: Request):
-    return templates.TemplateResponse("quadratic_program.html", {"request": request})
-
-@app.post("/quadratic_program", response_class=HTMLResponse)
-async def quadratic_program_post(request: Request, objective: str = Form(...), constraints: str = Form(...)):
-    try:
-        # Parse objective function
-        obj_terms = parse_expression(objective)
-        variables = {}
-        quad_coeffs = {}
-        linear_coeffs = {}
-
-        for coef, term in obj_terms:
-            if '^2' in term:
-                var_name = term.split('^')[0]
-                if var_name not in variables:
-                    variables[var_name] = cp.Variable()
-                quad_coeffs[var_name] = coef
-            else:
-                if term not in variables:
-                    variables[term] = cp.Variable()
-                linear_coeffs[term] = coef
-
-        # Construct objective function
-        objective_expr = sum(coef * variables[var]**2 for var, coef in quad_coeffs.items())
-        objective_expr += sum(coef * variables[var] for var, coef in linear_coeffs.items())
-
-        # Parse constraints
-        constraints_list = []
-        for constraint in constraints.split('\n'):
-            if constraint.strip():
-                if '<=' in constraint:
-                    lhs, rhs = constraint.split('<=')
-                    lhs_terms = parse_expression(lhs)
-                    lhs_expr = sum(coef * variables[var] for coef, var in lhs_terms)
-                    constraints_list.append(lhs_expr <= float(rhs.strip()))
-                elif '>=' in constraint:
-                    lhs, rhs = constraint.split('>=')
-                    lhs_terms = parse_expression(lhs)
-                    lhs_expr = sum(coef * variables[var] for coef, var in lhs_terms)
-                    constraints_list.append(lhs_expr >= float(rhs.strip()))
-
-        # Define and solve the CVXPY problem
-        prob = cp.Problem(cp.Minimize(objective_expr), constraints_list)
-        prob.solve()
-
-        # Prepare the result
-        if prob.status == cp.OPTIMAL:
-            result = f"Status: {prob.status}\n"
-            for var_name, var in variables.items():
-                result += f"{var_name} = {var.value}\n"
-            result += f"Objective value: {prob.value}"
-        else:
-            result = f"Status: {prob.status}"
-
-    except Exception as e:
-        result = f"An error occurred: {str(e)}"
-
-    return templates.TemplateResponse("quadratic_program.html", {"request": request, "result": result})
+app = create_app()
 
 if __name__ == "__main__":
+    import uvicorn
+
     uvicorn.run("app:app", host="0.0.0.0", port=8000, reload=True)

--- a/routes.py
+++ b/routes.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from solvers import solve_lp, solve_qp
+
+router = APIRouter()
+templates = Jinja2Templates(directory="templates")
+
+
+@router.get("/", response_class=HTMLResponse)
+async def root(request: Request) -> HTMLResponse:
+    """Render the homepage with links to optimization problems."""
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+@router.get("/linear_program", response_class=HTMLResponse)
+async def linear_program_get(request: Request) -> HTMLResponse:
+    """Display the linear programming input form."""
+    return templates.TemplateResponse("linear_program.html", {"request": request})
+
+
+@router.post("/linear_program", response_class=HTMLResponse)
+async def linear_program_post(
+    request: Request,
+    objective: str = Form(...),
+    constraints: str = Form(...),
+) -> HTMLResponse:
+    """Solve the provided linear program and return the result."""
+    try:
+        result = solve_lp(objective, constraints)
+    except Exception as exc:  # noqa: BLE001
+        result = f"An error occurred: {exc}"
+    return templates.TemplateResponse(
+        "linear_program.html", {"request": request, "result": result}
+    )
+
+
+@router.get("/quadratic_program", response_class=HTMLResponse)
+async def quadratic_program_get(request: Request) -> HTMLResponse:
+    """Display the quadratic programming input form."""
+    return templates.TemplateResponse(
+        "quadratic_program.html", {"request": request}
+    )
+
+
+@router.post("/quadratic_program", response_class=HTMLResponse)
+async def quadratic_program_post(
+    request: Request,
+    objective: str = Form(...),
+    constraints: str = Form(...),
+) -> HTMLResponse:
+    """Solve the provided quadratic program and return the result."""
+    try:
+        result = solve_qp(objective, constraints)
+    except Exception as exc:  # noqa: BLE001
+        result = f"An error occurred: {exc}"
+    return templates.TemplateResponse(
+        "quadratic_program.html", {"request": request, "result": result}
+    )

--- a/solvers.py
+++ b/solvers.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+import cvxpy as cp
+import pulp
+import re
+
+
+def parse_expression(expr: str) -> List[Tuple[float, str]]:
+    """Parse a simple algebraic expression into coefficient/variable terms."""
+    expr = expr.replace(" ", "")
+    terms = re.findall(r"([+-]?(?:\d*\.)?\d*)([a-zA-Z]\w*(?:\^2)?)", expr)
+    return [
+        (
+            float(coef)
+            if coef and coef not in ["+", "-"]
+            else (1.0 if coef != "-" else -1.0),
+            var,
+        )
+        for coef, var in terms
+        if var
+    ]
+
+
+def solve_lp(objective: str, constraints: str) -> str:
+    """Solve a linear program using PuLP.
+
+    Args:
+        objective: Objective function as a string, e.g. ``"3x + 2y"``.
+        constraints: Newline separated constraint expressions.
+
+    Returns:
+        Human readable string describing solver status and variable values.
+    """
+    prob = pulp.LpProblem("Linear Program", pulp.LpMinimize)
+
+    obj_terms = parse_expression(objective)
+    variables = {var: pulp.LpVariable(var) for _, var in obj_terms}
+
+    prob += pulp.lpSum(coef * variables[var] for coef, var in obj_terms)
+
+    for constraint in constraints.splitlines():
+        if not constraint.strip():
+            continue
+        if "<=" in constraint:
+            lhs, rhs = constraint.split("<=")
+            lhs_terms = parse_expression(lhs)
+            prob += (
+                pulp.lpSum(coef * variables[var] for coef, var in lhs_terms)
+                <= float(rhs.strip())
+            )
+        elif ">=" in constraint:
+            lhs, rhs = constraint.split(">=")
+            lhs_terms = parse_expression(lhs)
+            prob += (
+                pulp.lpSum(coef * variables[var] for coef, var in lhs_terms)
+                >= float(rhs.strip())
+            )
+
+    prob.solve()
+
+    status = pulp.LpStatus[prob.status]
+    if status == "Optimal":
+        result = f"Status: {status}\n"
+        for var in prob.variables():
+            result += f"{var.name} = {var.varValue}\n"
+        result += f"Objective value: {pulp.value(prob.objective)}"
+    else:
+        result = f"Status: {status}"
+    return result
+
+
+def solve_qp(objective: str, constraints: str) -> str:
+    """Solve a quadratic program using CVXPY.
+
+    Args:
+        objective: Quadratic objective as a string with ``^2`` for squared terms.
+        constraints: Newline separated constraint expressions.
+
+    Returns:
+        Human readable string describing solver status and solution values.
+    """
+    obj_terms = parse_expression(objective)
+    variables: Dict[str, cp.Variable] = {}
+    quad_coeffs: Dict[str, float] = {}
+    linear_coeffs: Dict[str, float] = {}
+
+    for coef, term in obj_terms:
+        if "^2" in term:
+            var_name = term.split("^")[0]
+            if var_name not in variables:
+                variables[var_name] = cp.Variable()
+            quad_coeffs[var_name] = coef
+        else:
+            if term not in variables:
+                variables[term] = cp.Variable()
+            linear_coeffs[term] = coef
+
+    objective_expr = sum(
+        coef * variables[var] ** 2 for var, coef in quad_coeffs.items()
+    )
+    objective_expr += sum(coef * variables[var] for var, coef in linear_coeffs.items())
+
+    constraints_list: List[cp.Constraint] = []
+    for constraint in constraints.splitlines():
+        if not constraint.strip():
+            continue
+        if "<=" in constraint:
+            lhs, rhs = constraint.split("<=")
+            lhs_terms = parse_expression(lhs)
+            lhs_expr = sum(coef * variables[var] for coef, var in lhs_terms)
+            constraints_list.append(lhs_expr <= float(rhs.strip()))
+        elif ">=" in constraint:
+            lhs, rhs = constraint.split(">=")
+            lhs_terms = parse_expression(lhs)
+            lhs_expr = sum(coef * variables[var] for coef, var in lhs_terms)
+            constraints_list.append(lhs_expr >= float(rhs.strip()))
+
+    prob = cp.Problem(cp.Minimize(objective_expr), constraints_list)
+    prob.solve()
+
+    if prob.status == cp.OPTIMAL:
+        result = f"Status: {prob.status}\n"
+        for var_name, var in variables.items():
+            result += f"{var_name} = {var.value}\n"
+        result += f"Objective value: {prob.value}"
+    else:
+        result = f"Status: {prob.status}"
+    return result


### PR DESCRIPTION
## Summary
- implement `solve_lp` and `solve_qp` in new `solvers` module
- move all endpoint logic to a router module
- keep `app.py` minimal with app creation and router registration

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845dc4f8aa8832a8b860830f5650c9f