### PR TITLE
Fix variable handling for LP constraints

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,11 +1,10 @@
-# codex/create-solvers-module-and-refactor-routes
 """FastAPI application setup."""
-=======
+
+from __future__ import annotations
+
 from fastapi import FastAPI, Request, Form
 from fastapi.templating import Jinja2Templates
 from fastapi.responses import HTMLResponse
-from pydantic import BaseModel
-import uvicorn
 import pulp
 import cvxpy as cp
 from parser import parse_polynomial, extract_linear_coeffs, extract_quadratic_terms
@@ -13,15 +12,9 @@ import sympy as sp
 import numpy as np
 import re
 
-# main
-
-from __future__ import annotations
-
-from fastapi import FastAPI
-
 from routes import router
 
-#  codex/create-solvers-module-and-refactor-routes
+templates = Jinja2Templates(directory="templates")
 
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
@@ -29,14 +22,13 @@ def create_app() -> FastAPI:
     application.include_router(router)
     return application
 
+
+app = create_app()
+
+
 @app.get("/", response_class=HTMLResponse)
 async def root(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
-# main
-
-
-# codex/create-solvers-module-and-refactor-routes
-app = create_app()
 
 @app.post("/linear_program", response_class=HTMLResponse)
 async def linear_program_post(request: Request, objective: str = Form(...), constraints: str = Form(...)):
@@ -96,6 +88,12 @@ async def linear_program_post(request: Request, objective: str = Form(...), cons
         # Constraints
         for lhs, op, rhs in parsed_constraints:
             lhs_syms, lhs_poly = parse_polynomial(lhs)
+            # Ensure any variables found in this constraint exist
+            for sym in lhs_syms:
+                name = str(sym)
+                if name not in variables:
+                    lb, ub = bounds.get(name, [None, None])
+                    variables[name] = pulp.LpVariable(name, lowBound=lb, upBound=ub)
             coeffs = extract_linear_coeffs(lhs_poly)
             lhs_expr = pulp.lpSum(coef * variables[var] for var, coef in coeffs.items())
             if op == "<=":

--- a/solvers.py
+++ b/solvers.py
@@ -38,6 +38,18 @@ def solve_lp(objective: str, constraints: str) -> str:
     obj_terms = parse_expression(objective)
     variables = {var: pulp.LpVariable(var) for _, var in obj_terms}
 
+    # Scan constraints for additional variables
+    for constraint in constraints.splitlines():
+        if "<=" in constraint:
+            lhs, _ = constraint.split("<=")
+        elif ">=" in constraint:
+            lhs, _ = constraint.split(">=")
+        else:
+            continue
+        for _, var in parse_expression(lhs):
+            if var not in variables:
+                variables[var] = pulp.LpVariable(var)
+
     prob += pulp.lpSum(coef * variables[var] for coef, var in obj_terms)
 
     for constraint in constraints.splitlines():

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1,0 +1,22 @@
+import re
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from solvers import solve_lp
+
+
+def test_solve_lp_creates_missing_variables():
+    result = solve_lp("x", "x + y <= 4\ny >= 1\nx >= 0")
+    assert "Status: Optimal" in result
+    values = {line.split("=")[0].strip(): float(line.split("=")[1])
+              for line in re.findall(r"^\w+ = [\d.-]+", result, re.MULTILINE)}
+    assert "y" in values
+
+def test_missing_var_multiple_constraints():
+    result = solve_lp("x", "y >= 2\nx + y >= 5\nx >= 0")
+    assert "Status: Optimal" in result
+    values = {line.split("=")[0].strip(): float(line.split("=")[1])
+              for line in re.findall(r"^\w+ = [\d.-]+", result, re.MULTILINE)}
+    assert "y" in values


### PR DESCRIPTION
## Summary
- create missing variables when building LP constraints
- ensure solver module also scans constraint variables
- clean up FastAPI app module
- add tests for using variables only in constraints

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ea900e44832ab94a6aefd13a4068