### PR TITLE
Fix README quadratic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,14 @@ The solver utilizes the CVXPY library to solve the quadratic program, offering:
 
 **Example Input**
 ```text
-Objective: 2x^2 + 3y^2 + xy + 4x + 5y
+Objective: 2x^2 + 3y^2 + 4x + 5y
 Constraints:
 x + y <= 10
 x >= 0
 y >= 0
 ```
+
+Cross terms in the objective function (e.g., `xy`) are currently unsupported.
 
 ### 3. Educational Content
 


### PR DESCRIPTION
## Summary
- clarify quadratic example to remove cross term
- note that cross terms are unsupported

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845fab528b8832a8da2614bb0352483