### PR TITLE
Add support for SDP, conic and geometric programs

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import re
 from typing import Dict, Tuple, List
 
+import cvxpy as cp
+import numpy as np
+
 import sympy as sp
 from sympy.parsing.sympy_parser import (
     parse_expr,
@@ -64,3 +67,30 @@ def extract_quadratic_terms(poly: sp.Poly) -> Tuple[Dict[Tuple[str, str], float]
         else:
             raise ValueError("Only quadratic expressions are supported")
     return quad, lin
+
+
+def parse_matrix(text: str) -> np.ndarray:
+    """Parse a semicolon-separated matrix string into a numpy array.
+
+    Each row in ``text`` should be separated by ``;`` and values within a row
+    should be comma separated, for example ``"1,0;0,1"`` for the 2x2 identity
+    matrix.
+    """
+    rows = [row.strip() for row in text.strip().split(";") if row.strip()]
+    return np.array([[float(v) for v in row.split(",") if v] for row in rows])
+
+
+def parse_vector(text: str) -> np.ndarray:
+    """Parse a comma separated vector string into a numpy array."""
+    return np.array([float(v) for v in text.strip().split(",") if v])
+
+
+def parse_posynomial(expr: str, variables: Dict[str, cp.Variable]) -> cp.Expression:
+    """Parse a (po)nomial expression string using CVXPY variables.
+
+    The expression may contain ``^`` for exponentiation and products using ``*``.
+    Variables present in ``variables`` can be used directly. The resulting
+    expression is created with ``eval`` in a restricted namespace.
+    """
+    expr_py = expr.replace("^", "**")
+    return eval(expr_py, {"__builtins__": {}}, variables)

--- a/routes.py
+++ b/routes.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
-from solvers import solve_lp, solve_qp
+from solvers import solve_lp, solve_qp, solve_sdp, solve_conic, solve_geometric
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
@@ -59,4 +59,70 @@ async def quadratic_program_post(
         result = f"An error occurred: {exc}"
     return templates.TemplateResponse(
         "quadratic_program.html", {"request": request, "result": result}
+    )
+
+
+@router.get("/semidefinite_program", response_class=HTMLResponse)
+async def sdp_get(request: Request) -> HTMLResponse:
+    """Display the semidefinite programming input form."""
+    return templates.TemplateResponse("semidefinite_program.html", {"request": request})
+
+
+@router.post("/semidefinite_program", response_class=HTMLResponse)
+async def sdp_post(
+    request: Request,
+    objective: str = Form(...),
+    constraints: str = Form(...),
+) -> HTMLResponse:
+    """Solve the provided semidefinite program and return the result."""
+    try:
+        result = solve_sdp(objective, constraints)
+    except Exception as exc:  # noqa: BLE001
+        result = f"An error occurred: {exc}"
+    return templates.TemplateResponse(
+        "semidefinite_program.html", {"request": request, "result": result}
+    )
+
+
+@router.get("/conic_program", response_class=HTMLResponse)
+async def conic_get(request: Request) -> HTMLResponse:
+    """Display the conic programming input form."""
+    return templates.TemplateResponse("conic_program.html", {"request": request})
+
+
+@router.post("/conic_program", response_class=HTMLResponse)
+async def conic_post(
+    request: Request,
+    objective: str = Form(...),
+    constraints: str = Form(...),
+) -> HTMLResponse:
+    """Solve the provided conic program and return the result."""
+    try:
+        result = solve_conic(objective, constraints)
+    except Exception as exc:  # noqa: BLE001
+        result = f"An error occurred: {exc}"
+    return templates.TemplateResponse(
+        "conic_program.html", {"request": request, "result": result}
+    )
+
+
+@router.get("/geometric_program", response_class=HTMLResponse)
+async def gp_get(request: Request) -> HTMLResponse:
+    """Display the geometric programming input form."""
+    return templates.TemplateResponse("geometric_program.html", {"request": request})
+
+
+@router.post("/geometric_program", response_class=HTMLResponse)
+async def gp_post(
+    request: Request,
+    objective: str = Form(...),
+    constraints: str = Form(...),
+) -> HTMLResponse:
+    """Solve the provided geometric program and return the result."""
+    try:
+        result = solve_geometric(objective, constraints)
+    except Exception as exc:  # noqa: BLE001
+        result = f"An error occurred: {exc}"
+    return templates.TemplateResponse(
+        "geometric_program.html", {"request": request, "result": result}
     )

--- a/templates/conic_program.html
+++ b/templates/conic_program.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Conic Programming Solver - Convex Optimization App</title>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; line-height: 1.6; padding: 20px; max-width: 800px; margin: 0 auto; }
+        h1, h2 { color: #333; }
+        form { background-color: #f0f0f0; padding: 20px; border-radius: 5px; }
+        label { display: block; margin-bottom: 5px; }
+        input[type="text"], textarea { width: 100%; padding: 8px; margin-bottom: 10px; border: 1px solid #ddd; border-radius: 4px; }
+        input[type="submit"] { background-color: #4CAF50; color: white; padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer; }
+        input[type="submit"]:hover { background-color: #45a049; }
+        #result { margin-top: 20px; padding: 10px; background-color: #e0e0e0; border-radius: 5px; }
+    </style>
+</head>
+<body>
+    <h1>Conic Programming Solver</h1>
+
+    <section id="explanation">
+        <h2>What is Conic Programming?</h2>
+        <p>Conic programs generalize linear and quadratic programs by allowing constraints described by convex cones. This simple interface supports linear constraints and optional second-order cone constraints using the notation <code>soc:A|b|c</code> meaning \(\|A x + b\|_2 \leq c\).</p>
+    </section>
+
+    <form action="/conic_program" method="post">
+        <label for="objective">Objective Coefficients (comma separated):</label>
+        <input type="text" id="objective" name="objective" required placeholder="e.g., 1,2,3">
+
+        <label for="constraints">Constraints (one per line):</label>
+        <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., 1,0,0 <= 5\nsoc:1,0;0,1|0,0|1"></textarea>
+
+        <input type="submit" value="Solve">
+    </form>
+
+    {% if result %}
+    <div id="result">
+        <h2>Result:</h2>
+        <pre>{{ result }}</pre>
+    </div>
+    {% endif %}
+
+    <p><a href="/">Back to Home</a></p>
+</body>
+</html>

--- a/templates/geometric_program.html
+++ b/templates/geometric_program.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Geometric Programming Solver - Convex Optimization App</title>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; line-height: 1.6; padding: 20px; max-width: 800px; margin: 0 auto; }
+        h1, h2 { color: #333; }
+        form { background-color: #f0f0f0; padding: 20px; border-radius: 5px; }
+        label { display: block; margin-bottom: 5px; }
+        input[type="text"], textarea { width: 100%; padding: 8px; margin-bottom: 10px; border: 1px solid #ddd; border-radius: 4px; }
+        input[type="submit"] { background-color: #4CAF50; color: white; padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer; }
+        input[type="submit"]:hover { background-color: #45a049; }
+        #result { margin-top: 20px; padding: 10px; background-color: #e0e0e0; border-radius: 5px; }
+    </style>
+</head>
+<body>
+    <h1>Geometric Programming Solver</h1>
+
+    <section id="explanation">
+        <h2>What is Geometric Programming?</h2>
+        <p>Geometric programs (GPs) are a class of problems with objective and constraint functions that are posynomials. Enter expressions using <code>^</code> for exponents and <code>*</code> for multiplication.</p>
+    </section>
+
+    <form action="/geometric_program" method="post">
+        <label for="objective">Objective Function:</label>
+        <input type="text" id="objective" name="objective" required placeholder="e.g., x^0.5 * y^0.5">
+
+        <label for="constraints">Constraints (one per line):</label>
+        <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., x * y <= 1"></textarea>
+
+        <input type="submit" value="Solve">
+    </form>
+
+    {% if result %}
+    <div id="result">
+        <h2>Result:</h2>
+        <pre>{{ result }}</pre>
+    </div>
+    {% endif %}
+
+    <p><a href="/">Back to Home</a></p>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,11 +31,17 @@
 
     <section id="optimization-problems">
         <h2>Explore Convex Optimization Problems</h2>
-        <p>This application provides tools for solving two common types of convex optimization problems:</p>
+        <p>This application provides tools for solving several types of convex optimization problems:</p>
         <a href="/linear_program" class="problem-link">Linear Programming</a>
         <p>Solve optimization problems with linear objective functions and linear constraints.</p>
         <a href="/quadratic_program" class="problem-link">Quadratic Programming</a>
         <p>Tackle problems with quadratic objective functions and linear constraints.</p>
+        <a href="/semidefinite_program" class="problem-link">Semidefinite Programming</a>
+        <p>Optimize a linear function subject to matrix variables being positive semidefinite.</p>
+        <a href="/conic_program" class="problem-link">Conic Programming</a>
+        <p>Solve programs with second-order cone constraints.</p>
+        <a href="/geometric_program" class="problem-link">Geometric Programming</a>
+        <p>Handle problems with posynomial objectives and constraints.</p>
         <a href="/visualize" class="problem-link">Visualization Tool</a>
         <p>Plot feasible regions and objective contours for small problems.</p>
     </section>

--- a/templates/semidefinite_program.html
+++ b/templates/semidefinite_program.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Semidefinite Programming Solver - Convex Optimization App</title>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; line-height: 1.6; padding: 20px; max-width: 800px; margin: 0 auto; }
+        h1, h2 { color: #333; }
+        form { background-color: #f0f0f0; padding: 20px; border-radius: 5px; }
+        label { display: block; margin-bottom: 5px; }
+        input[type="text"], textarea { width: 100%; padding: 8px; margin-bottom: 10px; border: 1px solid #ddd; border-radius: 4px; }
+        input[type="submit"] { background-color: #4CAF50; color: white; padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer; }
+        input[type="submit"]:hover { background-color: #45a049; }
+        #result { margin-top: 20px; padding: 10px; background-color: #e0e0e0; border-radius: 5px; }
+    </style>
+</head>
+<body>
+    <h1>Semidefinite Programming Solver</h1>
+
+    <section id="explanation">
+        <h2>What is Semidefinite Programming?</h2>
+        <p>Semidefinite programming (SDP) optimizes a linear function of a symmetric matrix subject to linear equality or inequality constraints and the matrix being positive semidefinite.</p>
+        <p>Provide matrices as comma separated rows with semicolons between rows, e.g. <code>1,0;0,1</code>.</p>
+    </section>
+
+    <form action="/semidefinite_program" method="post">
+        <label for="objective">Objective Matrix C:</label>
+        <input type="text" id="objective" name="objective" required placeholder="e.g., 1,0;0,1">
+
+        <label for="constraints">Constraints (one per line):</label>
+        <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., 1,0;0,1 <= 1"></textarea>
+
+        <input type="submit" value="Solve">
+    </form>
+
+    {% if result %}
+    <div id="result">
+        <h2>Result:</h2>
+        <pre>{{ result }}</pre>
+    </div>
+    {% endif %}
+
+    <p><a href="/">Back to Home</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend parser with helpers for matrices, vectors and posynomials
- implement `solve_sdp`, `solve_conic` and `solve_geometric`
- create new HTML templates and update index links
- add API routes that expose the new solvers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684610e2ff34832a8ed9f2c51bdf02a1