### PR TITLE
Add Plotly visualizations and animation route

### DIFF
--- a/templates/gradient_descent.html
+++ b/templates/gradient_descent.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gradient Descent Animation</title>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; line-height: 1.6; padding: 20px; max-width: 800px; margin: 0 auto; }
+        h1, h2 { color: #333; }
+        form { background-color: #f0f0f0; padding: 20px; border-radius: 5px; }
+        label { display: block; margin-bottom: 5px; }
+        input[type="text"] { width: 100%; padding: 8px; margin-bottom: 10px; border: 1px solid #ddd; border-radius: 4px; }
+        input[type="submit"] { background-color: #4CAF50; color: white; padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer; }
+        input[type="submit"]:hover { background-color: #45a049; }
+        #plot { margin-top: 20px; }
+    </style>
+</head>
+<body>
+    <h1>Gradient Descent Animation</h1>
+    <form action="/gradient_descent" method="post">
+        <label for="objective">Objective Function (quadratic):</label>
+        <input type="text" id="objective" name="objective" required placeholder="e.g., 2x^2 + y^2 + 4x + 5y">
+        <input type="submit" value="Animate">
+    </form>
+
+    {% if plot_html %}
+    <div id="plot">
+        <h2>Animation:</h2>
+        {{ plot_html | safe }}
+    </div>
+    {% endif %}
+
+    {% if result %}
+    <div id="result">
+        <pre>{{ result }}</pre>
+    </div>
+    {% endif %}
+
+    <p><a href="/">Back to Home</a></p>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -44,6 +44,8 @@
         <p>Handle problems with posynomial objectives and constraints.</p>
         <a href="/visualize" class="problem-link">Visualization Tool</a>
         <p>Plot feasible regions and objective contours for small problems.</p>
+        <a href="/gradient_descent" class="problem-link">Gradient Descent Animation</a>
+        <p>See a step-by-step visualization of the algorithm.</p>
     </section>
 </body>
 </html>

--- a/templates/linear_program.html
+++ b/templates/linear_program.html
@@ -49,6 +49,13 @@
     </div>
     {% endif %}
 
+    {% if plot_html %}
+    <div id="plot">
+        <h2>Visualization:</h2>
+        {{ plot_html | safe }}
+    </div>
+    {% endif %}
+
     <p><a href="/">Back to Home</a></p>
 </body>
 </html>

--- a/templates/quadratic_program.html
+++ b/templates/quadratic_program.html
@@ -50,6 +50,13 @@
     </div>
     {% endif %}
 
+    {% if plot_html %}
+    <div id="plot">
+        <h2>Visualization:</h2>
+        {{ plot_html | safe }}
+    </div>
+    {% endif %}
+
     <p><a href="/">Back to Home</a></p>
 </body>
 </html>

--- a/visualize.py
+++ b/visualize.py
@@ -1,0 +1,156 @@
+import numpy as np
+import plotly.graph_objects as go
+from typing import List, Tuple
+
+from solvers import parse_expression
+
+
+def _evaluate_expression(terms: List[Tuple[float, str]], X: np.ndarray, Y: np.ndarray) -> np.ndarray:
+    """Evaluate a parsed expression on a mesh grid."""
+    Z = np.zeros_like(X, dtype=float)
+    for coef, var in terms:
+        if var.endswith("^2"):
+            base = var[:-2]
+            if base == "x":
+                Z += coef * X**2
+            elif base == "y":
+                Z += coef * Y**2
+        else:
+            if var == "x":
+                Z += coef * X
+            elif var == "y":
+                Z += coef * Y
+    return Z
+
+
+def plot_linear_program(objective: str, constraints: str) -> go.Figure:
+    """Generate a 2D plot of the feasible region and objective contours."""
+    obj_terms = parse_expression(objective)
+
+    x = np.linspace(-5, 5, 200)
+    y = np.linspace(-5, 5, 200)
+    X, Y = np.meshgrid(x, y)
+
+    Z = _evaluate_expression(obj_terms, X, Y)
+
+    mask = np.ones_like(X, dtype=bool)
+    for line in constraints.splitlines():
+        if not line.strip():
+            continue
+        if "<=" in line:
+            lhs, rhs = line.split("<=")
+            lhs_terms = parse_expression(lhs)
+            lhs_val = _evaluate_expression(lhs_terms, X, Y)
+            mask &= lhs_val <= float(rhs.strip())
+        elif ">=" in line:
+            lhs, rhs = line.split(">=")
+            lhs_terms = parse_expression(lhs)
+            lhs_val = _evaluate_expression(lhs_terms, X, Y)
+            mask &= lhs_val >= float(rhs.strip())
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Contour(x=x, y=y, z=Z, contours=dict(showlabels=True), showscale=False)
+    )
+    fig.add_trace(
+        go.Heatmap(
+            x=x,
+            y=y,
+            z=mask.astype(int),
+            showscale=False,
+            opacity=0.3,
+            colorscale=[[0, "rgba(0,0,0,0)"], [1, "rgba(0,200,0,0.4)"]],
+        )
+    )
+    fig.update_layout(
+        title="Feasible Region and Objective Contours",
+        xaxis_title="x",
+        yaxis_title="y",
+    )
+    return fig
+
+
+def plot_quadratic_program(objective: str) -> go.Figure:
+    """Generate a 3D surface plot of a quadratic objective."""
+    obj_terms = parse_expression(objective)
+
+    x = np.linspace(-5, 5, 100)
+    y = np.linspace(-5, 5, 100)
+    X, Y = np.meshgrid(x, y)
+    Z = _evaluate_expression(obj_terms, X, Y)
+
+    fig = go.Figure(data=[go.Surface(x=x, y=y, z=Z, colorscale="Viridis")])
+    fig.update_layout(
+        title="Objective Surface",
+        scene=dict(xaxis_title="x", yaxis_title="y", zaxis_title="f(x,y)"),
+    )
+    return fig
+
+
+def gradient_descent_animation(objective: str, steps: int = 30, lr: float = 0.1) -> go.Figure:
+    """Create an animated gradient descent path on the objective surface."""
+    obj_terms = parse_expression(objective)
+
+    x = np.linspace(-5, 5, 100)
+    y = np.linspace(-5, 5, 100)
+    X, Y = np.meshgrid(x, y)
+    Z = _evaluate_expression(obj_terms, X, Y)
+
+    point = np.array([4.0, 4.0])
+    path = [point.copy()]
+    for _ in range(steps):
+        grad = np.zeros(2)
+        px, py = point
+        for coef, var in obj_terms:
+            if var.endswith("^2"):
+                base = var[:-2]
+                if base == "x":
+                    grad[0] += 2 * coef * px
+                elif base == "y":
+                    grad[1] += 2 * coef * py
+            else:
+                if var == "x":
+                    grad[0] += coef
+                elif var == "y":
+                    grad[1] += coef
+        point = point - lr * grad
+        path.append(point.copy())
+    path = np.array(path)
+
+    base_contour = go.Contour(x=x, y=y, z=Z, contours=dict(showlabels=True), showscale=False)
+
+    frames = [
+        go.Frame(data=[base_contour, go.Scatter(x=path[:1,0], y=path[:1,1], mode="markers+lines", line=dict(color="red"))])
+    ]
+    for i in range(1, len(path)):
+        frames.append(
+            go.Frame(
+                data=[
+                    base_contour,
+                    go.Scatter(
+                        x=path[: i + 1, 0],
+                        y=path[: i + 1, 1],
+                        mode="markers+lines",
+                        line=dict(color="red"),
+                    ),
+                ]
+            )
+        )
+
+    fig = go.Figure(
+        data=[base_contour, go.Scatter(x=[path[0,0]], y=[path[0,1]], mode="markers+lines", line=dict(color="red"))],
+        frames=frames,
+    )
+    fig.update_layout(
+        title="Gradient Descent Animation",
+        xaxis_title="x",
+        yaxis_title="y",
+        updatemenus=[
+            dict(
+                type="buttons",
+                showactive=False,
+                buttons=[dict(label="Play", method="animate", args=[None])],
+            )
+        ],
+    )
+    return fig


### PR DESCRIPTION
## Summary
- implement new Plotly-based plotting utilities in `visualize.py`
- update solver routes to return Plotly plots
- extend linear and quadratic program templates to embed plots
- add gradient descent animation route and template
- link animation page from the index

## Testing
- `pip install cvxpy pulp plotly numpy pytest -q`
- `pip install sympy -q`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846273eab34832a8986f227dcc5ac54