### PR TITLE
Add example problem library

### DIFF
--- a/problems/examples.yaml
+++ b/problems/examples.yaml
@@ -1,0 +1,36 @@
+- name: Simple LP
+  type: linear_program
+  description: "Minimize 3x + 2y with basic constraints."
+  objective: "3x + 2y"
+  constraints:
+    - "x + y <= 4"
+    - "x >= 0"
+    - "y >= 0"
+- name: Quadratic Example
+  type: quadratic_program
+  description: "Minimize x^2 + y^2 + x subject to linear constraints."
+  objective: "x^2 + y^2 + x"
+  constraints:
+    - "x + y >= 1"
+    - "x >= 0"
+    - "y >= 0"
+- name: Simple SDP
+  type: semidefinite_program
+  description: "Minimize trace(CX) subject to a single constraint."
+  objective: "1,0;0,1"
+  constraints:
+    - "1,0;0,1 >= 1"
+- name: Conic Example
+  type: conic_program
+  description: "Second-order cone constraint with linear objective."
+  objective: "1,1"
+  constraints:
+    - "soc:1,0;0,1|0,0|1"
+- name: Geometric Example
+  type: geometric_program
+  description: "Simple geometric program."
+  objective: "x*y"
+  constraints:
+    - "x*y >= 1"
+    - "x >= 1"
+    - "y >= 1"

--- a/routes.py
+++ b/routes.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Form, Request
+from fastapi import APIRouter, Form, Request, Query
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
 from solvers import solve_lp, solve_qp, solve_sdp, solve_conic, solve_geometric
 import plotly.io as pio
+import os
+import json
+import yaml
 from visualize import (
     gradient_descent_animation,
     plot_linear_program,
@@ -16,16 +19,63 @@ router = APIRouter()
 templates = Jinja2Templates(directory="templates")
 
 
+def load_problems() -> list[dict]:
+    """Load example problems from the ``problems`` directory."""
+    problems = []
+    if not os.path.isdir("problems"):
+        return problems
+    for fname in sorted(os.listdir("problems")):
+        path = os.path.join("problems", fname)
+        if fname.endswith((".yaml", ".yml")):
+            with open(path, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+        elif fname.endswith(".json"):
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        else:
+            continue
+        if isinstance(data, list):
+            problems.extend(data)
+        else:
+            problems.append(data)
+    return problems
+
+
 @router.get("/", response_class=HTMLResponse)
 async def root(request: Request) -> HTMLResponse:
     """Render the homepage with links to optimization problems."""
     return templates.TemplateResponse("index.html", {"request": request})
 
 
+@router.get("/problems", response_class=HTMLResponse)
+async def problem_library(
+    request: Request, problem: str | None = Query(default=None)
+) -> HTMLResponse:
+    """Display available example problems and selected problem details."""
+    problems = load_problems()
+    selected = None
+    if problem:
+        for p in problems:
+            if p.get("name") == problem:
+                selected = p
+                break
+    return templates.TemplateResponse(
+        "problem_library.html",
+        {"request": request, "problems": problems, "selected": selected},
+    )
+
+
 @router.get("/linear_program", response_class=HTMLResponse)
-async def linear_program_get(request: Request) -> HTMLResponse:
+async def linear_program_get(
+    request: Request,
+    objective: str | None = Query(default=None),
+    constraints: str | None = Query(default=None),
+) -> HTMLResponse:
     """Display the linear programming input form."""
-    return templates.TemplateResponse("linear_program.html", {"request": request})
+    return templates.TemplateResponse(
+        "linear_program.html",
+        {"request": request, "objective": objective, "constraints": constraints},
+    )
 
 
 @router.post("/linear_program", response_class=HTMLResponse)
@@ -49,10 +99,19 @@ async def linear_program_post(
 
 
 @router.get("/quadratic_program", response_class=HTMLResponse)
-async def quadratic_program_get(request: Request) -> HTMLResponse:
+async def quadratic_program_get(
+    request: Request,
+    objective: str | None = Query(default=None),
+    constraints: str | None = Query(default=None),
+) -> HTMLResponse:
     """Display the quadratic programming input form."""
     return templates.TemplateResponse(
-        "quadratic_program.html", {"request": request}
+        "quadratic_program.html",
+        {
+            "request": request,
+            "objective": objective,
+            "constraints": constraints,
+        },
     )
 
 
@@ -77,9 +136,20 @@ async def quadratic_program_post(
 
 
 @router.get("/semidefinite_program", response_class=HTMLResponse)
-async def sdp_get(request: Request) -> HTMLResponse:
+async def sdp_get(
+    request: Request,
+    objective: str | None = Query(default=None),
+    constraints: str | None = Query(default=None),
+) -> HTMLResponse:
     """Display the semidefinite programming input form."""
-    return templates.TemplateResponse("semidefinite_program.html", {"request": request})
+    return templates.TemplateResponse(
+        "semidefinite_program.html",
+        {
+            "request": request,
+            "objective": objective,
+            "constraints": constraints,
+        },
+    )
 
 
 @router.post("/semidefinite_program", response_class=HTMLResponse)
@@ -99,9 +169,20 @@ async def sdp_post(
 
 
 @router.get("/conic_program", response_class=HTMLResponse)
-async def conic_get(request: Request) -> HTMLResponse:
+async def conic_get(
+    request: Request,
+    objective: str | None = Query(default=None),
+    constraints: str | None = Query(default=None),
+) -> HTMLResponse:
     """Display the conic programming input form."""
-    return templates.TemplateResponse("conic_program.html", {"request": request})
+    return templates.TemplateResponse(
+        "conic_program.html",
+        {
+            "request": request,
+            "objective": objective,
+            "constraints": constraints,
+        },
+    )
 
 
 @router.post("/conic_program", response_class=HTMLResponse)
@@ -121,9 +202,20 @@ async def conic_post(
 
 
 @router.get("/geometric_program", response_class=HTMLResponse)
-async def gp_get(request: Request) -> HTMLResponse:
+async def gp_get(
+    request: Request,
+    objective: str | None = Query(default=None),
+    constraints: str | None = Query(default=None),
+) -> HTMLResponse:
     """Display the geometric programming input form."""
-    return templates.TemplateResponse("geometric_program.html", {"request": request})
+    return templates.TemplateResponse(
+        "geometric_program.html",
+        {
+            "request": request,
+            "objective": objective,
+            "constraints": constraints,
+        },
+    )
 
 
 @router.post("/geometric_program", response_class=HTMLResponse)
@@ -143,9 +235,15 @@ async def gp_post(
 
 
 @router.get("/gradient_descent", response_class=HTMLResponse)
-async def gradient_descent_get(request: Request) -> HTMLResponse:
+async def gradient_descent_get(
+    request: Request,
+    objective: str | None = Query(default=None),
+) -> HTMLResponse:
     """Display the gradient descent animation form."""
-    return templates.TemplateResponse("gradient_descent.html", {"request": request})
+    return templates.TemplateResponse(
+        "gradient_descent.html",
+        {"request": request, "objective": objective},
+    )
 
 
 @router.post("/gradient_descent", response_class=HTMLResponse)

--- a/templates/conic_program.html
+++ b/templates/conic_program.html
@@ -27,10 +27,10 @@
 
     <form action="/conic_program" method="post">
         <label for="objective">Objective Coefficients (comma separated):</label>
-        <input type="text" id="objective" name="objective" required placeholder="e.g., 1,2,3">
+        <input type="text" id="objective" name="objective" required placeholder="e.g., 1,2,3" value="{{ objective or '' }}">
 
         <label for="constraints">Constraints (one per line):</label>
-        <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., 1,0,0 <= 5\nsoc:1,0;0,1|0,0|1"></textarea>
+        <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., 1,0,0 <= 5\nsoc:1,0;0,1|0,0|1">{{ constraints or '' }}</textarea>
 
         <input type="submit" value="Solve">
     </form>

--- a/templates/geometric_program.html
+++ b/templates/geometric_program.html
@@ -27,10 +27,10 @@
 
     <form action="/geometric_program" method="post">
         <label for="objective">Objective Function:</label>
-        <input type="text" id="objective" name="objective" required placeholder="e.g., x^0.5 * y^0.5">
+        <input type="text" id="objective" name="objective" required placeholder="e.g., x^0.5 * y^0.5" value="{{ objective or '' }}">
 
         <label for="constraints">Constraints (one per line):</label>
-        <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., x * y <= 1"></textarea>
+        <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., x * y <= 1">{{ constraints or '' }}</textarea>
 
         <input type="submit" value="Solve">
     </form>

--- a/templates/gradient_descent.html
+++ b/templates/gradient_descent.html
@@ -21,7 +21,7 @@
     <h1>Gradient Descent Animation</h1>
     <form action="/gradient_descent" method="post">
         <label for="objective">Objective Function (quadratic):</label>
-        <input type="text" id="objective" name="objective" required placeholder="e.g., 2x^2 + y^2 + 4x + 5y">
+        <input type="text" id="objective" name="objective" required placeholder="e.g., 2x^2 + y^2 + 4x + 5y" value="{{ objective or '' }}">
         <input type="submit" value="Animate">
     </form>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -44,6 +44,8 @@
         <p>Handle problems with posynomial objectives and constraints.</p>
         <a href="/visualize" class="problem-link">Visualization Tool</a>
         <p>Plot feasible regions and objective contours for small problems.</p>
+        <a href="/problems" class="problem-link">Problem Library</a>
+        <p>Browse sample problems and load them into a solver.</p>
         <a href="/gradient_descent" class="problem-link">Gradient Descent Animation</a>
         <p>See a step-by-step visualization of the algorithm.</p>
     </section>

--- a/templates/linear_program.html
+++ b/templates/linear_program.html
@@ -34,10 +34,10 @@
 
     <form action="/linear_program" method="post">
         <label for="objective">Objective Function:</label>
-        <input type="text" id="objective" name="objective" required placeholder="e.g., 3x + 2y">
+        <input type="text" id="objective" name="objective" required placeholder="e.g., 3x + 2y" value="{{ objective or '' }}">
         
         <label for="constraints">Constraints (one per line):</label>
-        <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., x + y <= 10&#10;x >= 0&#10;y >= 0"></textarea>
+        <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., x + y <= 10&#10;x >= 0&#10;y >= 0">{{ constraints or '' }}</textarea>
         
         <input type="submit" value="Solve">
     </form>

--- a/templates/problem_library.html
+++ b/templates/problem_library.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Problem Library</title>
+    <style>
+        body { font-family: Arial, sans-serif; line-height: 1.6; padding: 20px; max-width: 800px; margin: 0 auto; }
+        h1, h2 { color: #333; }
+        .problem-list { list-style: none; padding: 0; }
+        .problem-list li { margin-bottom: 8px; }
+        .problem-list a { text-decoration: none; background: #f0f0f0; padding: 6px 10px; border-radius: 4px; display: inline-block; }
+        .problem-list a:hover { background: #e0e0e0; }
+        form { background-color: #f9f9f9; padding: 20px; border-radius: 5px; margin-top: 20px; }
+    </style>
+</head>
+<body>
+    <h1>Problem Library</h1>
+    <ul class="problem-list">
+        {% for p in problems %}
+        <li><a href="/problems?problem={{ p.name | urlencode }}">{{ p.name }}</a></li>
+        {% endfor %}
+    </ul>
+
+    {% if selected %}
+    <h2>{{ selected.name }}</h2>
+    <p>{{ selected.description }}</p>
+    <form action="/{{ selected.type }}" method="get">
+        <input type="hidden" name="objective" value="{{ selected.objective }}">
+        <input type="hidden" name="constraints" value="{{ '\n'.join(selected.constraints) if selected.constraints }}">
+        <input type="submit" value="Load Problem">
+    </form>
+    {% endif %}
+
+    <p><a href="/">Back to Home</a></p>
+</body>
+</html>

--- a/templates/quadratic_program.html
+++ b/templates/quadratic_program.html
@@ -35,10 +35,10 @@
     <form action="/quadratic_program" method="post">
         <label for="objective">Objective Function (quadratic terms followed by linear terms):</label>
         <!-- Cross terms like xy are not yet supported by the parser -->
-        <input type="text" id="objective" name="objective" required placeholder="e.g., 2x^2 + 3y^2 + 4x + 5y">
+        <input type="text" id="objective" name="objective" required placeholder="e.g., 2x^2 + 3y^2 + 4x + 5y" value="{{ objective or '' }}">
         
         <label for="constraints">Constraints (one per line):</label>
-        <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., x + y <= 10&#10;x >= 0&#10;y >= 0"></textarea>
+        <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., x + y <= 10&#10;x >= 0&#10;y >= 0">{{ constraints or '' }}</textarea>
         
         <input type="submit" value="Solve">
     </form>

--- a/templates/semidefinite_program.html
+++ b/templates/semidefinite_program.html
@@ -28,10 +28,10 @@
 
     <form action="/semidefinite_program" method="post">
         <label for="objective">Objective Matrix C:</label>
-        <input type="text" id="objective" name="objective" required placeholder="e.g., 1,0;0,1">
+        <input type="text" id="objective" name="objective" required placeholder="e.g., 1,0;0,1" value="{{ objective or '' }}">
 
         <label for="constraints">Constraints (one per line):</label>
-        <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., 1,0;0,1 <= 1"></textarea>
+        <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., 1,0;0,1 <= 1">{{ constraints or '' }}</textarea>
 
         <input type="submit" value="Solve">
     </form>


### PR DESCRIPTION
## Summary
- allow prefilling forms via query parameters
- list example problems from new `problems/` folder
- link to library from home page
- show default values in form templates

## Testing
- `pip install cvxpy pulp sympy plotly pytest --quiet`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846319e639c832a938b654cd0c1639d