### PR TITLE
Add solver configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ x >= 0
 y >= 0
 ```
 
+### Solver Options
+
+Each solver accepts optional parameters:
+
+- **method**: choose the backend algorithm (e.g. `cbc` for LP, `ECOS` or `SCS` for convex programs).
+- **max_iter**: limit the number of iterations the solver will run.
+- **tolerance**: stopping tolerance passed to the solver.
+
+If an unsupported method is supplied, the application will return an error.
+
 <!-- codex/add-route-for-2d-plots-visualization -->
 ### 3. Visualization Tool
 

--- a/routes.py
+++ b/routes.py
@@ -70,11 +70,21 @@ async def linear_program_get(
     request: Request,
     objective: str | None = Query(default=None),
     constraints: str | None = Query(default=None),
+    method: str | None = Query(default=None),
+    max_iter: int | None = Query(default=None),
+    tolerance: float | None = Query(default=None),
 ) -> HTMLResponse:
     """Display the linear programming input form."""
     return templates.TemplateResponse(
         "linear_program.html",
-        {"request": request, "objective": objective, "constraints": constraints},
+        {
+            "request": request,
+            "objective": objective,
+            "constraints": constraints,
+            "method": method,
+            "max_iter": max_iter,
+            "tolerance": tolerance,
+        },
     )
 
 
@@ -83,10 +93,19 @@ async def linear_program_post(
     request: Request,
     objective: str = Form(...),
     constraints: str = Form(...),
+    method: str | None = Form(default=None),
+    max_iter: int | None = Form(default=None),
+    tolerance: float | None = Form(default=None),
 ) -> HTMLResponse:
     """Solve the provided linear program and return the result."""
     try:
-        result = solve_lp(objective, constraints)
+        result = solve_lp(
+            objective,
+            constraints,
+            method=method,
+            max_iter=max_iter,
+            tolerance=tolerance,
+        )
         fig = plot_linear_program(objective, constraints)
         plot_html = pio.to_html(fig, include_plotlyjs="cdn")
     except Exception as exc:  # noqa: BLE001
@@ -94,7 +113,14 @@ async def linear_program_post(
         plot_html = None
     return templates.TemplateResponse(
         "linear_program.html",
-        {"request": request, "result": result, "plot_html": plot_html},
+        {
+            "request": request,
+            "result": result,
+            "plot_html": plot_html,
+            "method": method,
+            "max_iter": max_iter,
+            "tolerance": tolerance,
+        },
     )
 
 
@@ -103,6 +129,9 @@ async def quadratic_program_get(
     request: Request,
     objective: str | None = Query(default=None),
     constraints: str | None = Query(default=None),
+    method: str | None = Query(default=None),
+    max_iter: int | None = Query(default=None),
+    tolerance: float | None = Query(default=None),
 ) -> HTMLResponse:
     """Display the quadratic programming input form."""
     return templates.TemplateResponse(
@@ -111,6 +140,9 @@ async def quadratic_program_get(
             "request": request,
             "objective": objective,
             "constraints": constraints,
+            "method": method,
+            "max_iter": max_iter,
+            "tolerance": tolerance,
         },
     )
 
@@ -120,10 +152,19 @@ async def quadratic_program_post(
     request: Request,
     objective: str = Form(...),
     constraints: str = Form(...),
+    method: str | None = Form(default=None),
+    max_iter: int | None = Form(default=None),
+    tolerance: float | None = Form(default=None),
 ) -> HTMLResponse:
     """Solve the provided quadratic program and return the result."""
     try:
-        result = solve_qp(objective, constraints)
+        result = solve_qp(
+            objective,
+            constraints,
+            method=method,
+            max_iter=max_iter,
+            tolerance=tolerance,
+        )
         fig = plot_quadratic_program(objective)
         plot_html = pio.to_html(fig, include_plotlyjs="cdn")
     except Exception as exc:  # noqa: BLE001
@@ -131,7 +172,14 @@ async def quadratic_program_post(
         plot_html = None
     return templates.TemplateResponse(
         "quadratic_program.html",
-        {"request": request, "result": result, "plot_html": plot_html},
+        {
+            "request": request,
+            "result": result,
+            "plot_html": plot_html,
+            "method": method,
+            "max_iter": max_iter,
+            "tolerance": tolerance,
+        },
     )
 
 
@@ -140,6 +188,9 @@ async def sdp_get(
     request: Request,
     objective: str | None = Query(default=None),
     constraints: str | None = Query(default=None),
+    method: str | None = Query(default=None),
+    max_iter: int | None = Query(default=None),
+    tolerance: float | None = Query(default=None),
 ) -> HTMLResponse:
     """Display the semidefinite programming input form."""
     return templates.TemplateResponse(
@@ -148,6 +199,9 @@ async def sdp_get(
             "request": request,
             "objective": objective,
             "constraints": constraints,
+            "method": method,
+            "max_iter": max_iter,
+            "tolerance": tolerance,
         },
     )
 
@@ -157,14 +211,30 @@ async def sdp_post(
     request: Request,
     objective: str = Form(...),
     constraints: str = Form(...),
+    method: str | None = Form(default=None),
+    max_iter: int | None = Form(default=None),
+    tolerance: float | None = Form(default=None),
 ) -> HTMLResponse:
     """Solve the provided semidefinite program and return the result."""
     try:
-        result = solve_sdp(objective, constraints)
+        result = solve_sdp(
+            objective,
+            constraints,
+            method=method,
+            max_iter=max_iter,
+            tolerance=tolerance,
+        )
     except Exception as exc:  # noqa: BLE001
         result = f"An error occurred: {exc}"
     return templates.TemplateResponse(
-        "semidefinite_program.html", {"request": request, "result": result}
+        "semidefinite_program.html",
+        {
+            "request": request,
+            "result": result,
+            "method": method,
+            "max_iter": max_iter,
+            "tolerance": tolerance,
+        },
     )
 
 
@@ -173,6 +243,9 @@ async def conic_get(
     request: Request,
     objective: str | None = Query(default=None),
     constraints: str | None = Query(default=None),
+    method: str | None = Query(default=None),
+    max_iter: int | None = Query(default=None),
+    tolerance: float | None = Query(default=None),
 ) -> HTMLResponse:
     """Display the conic programming input form."""
     return templates.TemplateResponse(
@@ -181,6 +254,9 @@ async def conic_get(
             "request": request,
             "objective": objective,
             "constraints": constraints,
+            "method": method,
+            "max_iter": max_iter,
+            "tolerance": tolerance,
         },
     )
 
@@ -190,14 +266,30 @@ async def conic_post(
     request: Request,
     objective: str = Form(...),
     constraints: str = Form(...),
+    method: str | None = Form(default=None),
+    max_iter: int | None = Form(default=None),
+    tolerance: float | None = Form(default=None),
 ) -> HTMLResponse:
     """Solve the provided conic program and return the result."""
     try:
-        result = solve_conic(objective, constraints)
+        result = solve_conic(
+            objective,
+            constraints,
+            method=method,
+            max_iter=max_iter,
+            tolerance=tolerance,
+        )
     except Exception as exc:  # noqa: BLE001
         result = f"An error occurred: {exc}"
     return templates.TemplateResponse(
-        "conic_program.html", {"request": request, "result": result}
+        "conic_program.html",
+        {
+            "request": request,
+            "result": result,
+            "method": method,
+            "max_iter": max_iter,
+            "tolerance": tolerance,
+        }
     )
 
 
@@ -206,6 +298,9 @@ async def gp_get(
     request: Request,
     objective: str | None = Query(default=None),
     constraints: str | None = Query(default=None),
+    method: str | None = Query(default=None),
+    max_iter: int | None = Query(default=None),
+    tolerance: float | None = Query(default=None),
 ) -> HTMLResponse:
     """Display the geometric programming input form."""
     return templates.TemplateResponse(
@@ -214,6 +309,9 @@ async def gp_get(
             "request": request,
             "objective": objective,
             "constraints": constraints,
+            "method": method,
+            "max_iter": max_iter,
+            "tolerance": tolerance,
         },
     )
 
@@ -223,14 +321,30 @@ async def gp_post(
     request: Request,
     objective: str = Form(...),
     constraints: str = Form(...),
+    method: str | None = Form(default=None),
+    max_iter: int | None = Form(default=None),
+    tolerance: float | None = Form(default=None),
 ) -> HTMLResponse:
     """Solve the provided geometric program and return the result."""
     try:
-        result = solve_geometric(objective, constraints)
+        result = solve_geometric(
+            objective,
+            constraints,
+            method=method,
+            max_iter=max_iter,
+            tolerance=tolerance,
+        )
     except Exception as exc:  # noqa: BLE001
         result = f"An error occurred: {exc}"
     return templates.TemplateResponse(
-        "geometric_program.html", {"request": request, "result": result}
+        "geometric_program.html",
+        {
+            "request": request,
+            "result": result,
+            "method": method,
+            "max_iter": max_iter,
+            "tolerance": tolerance,
+        },
     )
 
 

--- a/solvers.py
+++ b/solvers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 
 import cvxpy as cp
 import pulp
@@ -26,7 +26,13 @@ def parse_expression(expr: str) -> List[Tuple[float, str]]:
     ]
 
 
-def solve_lp(objective: str, constraints: str) -> str:
+def solve_lp(
+    objective: str,
+    constraints: str,
+    method: Optional[str] = None,
+    max_iter: Optional[int] = None,
+    tolerance: Optional[float] = None,
+) -> str:
     """Solve a linear program using PuLP.
 
     Args:
@@ -73,7 +79,17 @@ def solve_lp(objective: str, constraints: str) -> str:
                 >= float(rhs.strip())
             )
 
-    prob.solve()
+    # Determine solver
+    solver_name = (method or "cbc").lower()
+    solvers = {"cbc": pulp.PULP_CBC_CMD, "glpk": pulp.GLPK_CMD}
+    if solver_name not in solvers:
+        raise ValueError(f"Unsupported method '{method}'")
+    solver_kwargs = {"msg": False}
+    if max_iter is not None:
+        solver_kwargs["timeLimit"] = int(max_iter)
+    if tolerance is not None:
+        solver_kwargs["gapRel"] = float(tolerance)
+    prob.solve(solvers[solver_name](**solver_kwargs))
 
     status = pulp.LpStatus[prob.status]
     if status == "Optimal":
@@ -86,7 +102,13 @@ def solve_lp(objective: str, constraints: str) -> str:
     return result
 
 
-def solve_qp(objective: str, constraints: str) -> str:
+def solve_qp(
+    objective: str,
+    constraints: str,
+    method: Optional[str] = None,
+    max_iter: Optional[int] = None,
+    tolerance: Optional[float] = None,
+) -> str:
     """Solve a quadratic program using CVXPY.
 
     Args:
@@ -133,7 +155,28 @@ def solve_qp(objective: str, constraints: str) -> str:
             constraints_list.append(lhs_expr >= float(rhs.strip()))
 
     prob = cp.Problem(cp.Minimize(objective_expr), constraints_list)
-    prob.solve()
+
+    solver_name = (method or "ECOS").upper()
+    valid_methods = {"ECOS", "OSQP", "SCS"}
+    if solver_name not in valid_methods:
+        raise ValueError(f"Unsupported method '{method}'")
+    solve_kwargs = {}
+    if max_iter is not None:
+        if solver_name == "OSQP":
+            solve_kwargs["max_iter"] = int(max_iter)
+        else:
+            solve_kwargs["max_iters"] = int(max_iter)
+    if tolerance is not None:
+        if solver_name == "SCS":
+            solve_kwargs["eps"] = float(tolerance)
+        elif solver_name == "OSQP":
+            solve_kwargs["eps_abs"] = float(tolerance)
+            solve_kwargs["eps_rel"] = float(tolerance)
+        else:
+            solve_kwargs["abstol"] = float(tolerance)
+            solve_kwargs["reltol"] = float(tolerance)
+
+    prob.solve(solver=solver_name, **solve_kwargs)
 
     if prob.status == cp.OPTIMAL:
         result = f"Status: {prob.status}\n"
@@ -145,7 +188,13 @@ def solve_qp(objective: str, constraints: str) -> str:
     return result
 
 
-def solve_sdp(objective: str, constraints: str) -> str:
+def solve_sdp(
+    objective: str,
+    constraints: str,
+    method: Optional[str] = None,
+    max_iter: Optional[int] = None,
+    tolerance: Optional[float] = None,
+) -> str:
     """Solve a small semidefinite program.
 
     Parameters in ``objective`` and ``constraints`` should be provided as matrix
@@ -176,7 +225,16 @@ def solve_sdp(objective: str, constraints: str) -> str:
             constr.append(cp.trace(A @ X) == float(b_str.strip()))
 
     prob = cp.Problem(cp.Minimize(cp.trace(C @ X)), constr)
-    prob.solve(solver=cp.SCS)
+
+    solver_name = (method or "SCS").upper()
+    if solver_name not in {"SCS"}:
+        raise ValueError(f"Unsupported method '{method}'")
+    solve_kwargs = {}
+    if max_iter is not None:
+        solve_kwargs["max_iters"] = int(max_iter)
+    if tolerance is not None:
+        solve_kwargs["eps"] = float(tolerance)
+    prob.solve(solver=solver_name, **solve_kwargs)
 
     if prob.status == cp.OPTIMAL:
         result = f"Status: {prob.status}\n"
@@ -187,7 +245,13 @@ def solve_sdp(objective: str, constraints: str) -> str:
     return result
 
 
-def solve_conic(objective: str, constraints: str) -> str:
+def solve_conic(
+    objective: str,
+    constraints: str,
+    method: Optional[str] = None,
+    max_iter: Optional[int] = None,
+    tolerance: Optional[float] = None,
+) -> str:
     """Solve a basic conic program using second-order cone constraints."""
 
     c = parse_vector(objective)
@@ -216,7 +280,16 @@ def solve_conic(objective: str, constraints: str) -> str:
             constr.append(a @ x >= float(b_val.strip()))
 
     prob = cp.Problem(cp.Minimize(c @ x), constr)
-    prob.solve(solver=cp.SCS)
+
+    solver_name = (method or "SCS").upper()
+    if solver_name not in {"SCS"}:
+        raise ValueError(f"Unsupported method '{method}'")
+    solve_kwargs = {}
+    if max_iter is not None:
+        solve_kwargs["max_iters"] = int(max_iter)
+    if tolerance is not None:
+        solve_kwargs["eps"] = float(tolerance)
+    prob.solve(solver=solver_name, **solve_kwargs)
 
     if prob.status == cp.OPTIMAL:
         result = f"Status: {prob.status}\n"
@@ -227,7 +300,13 @@ def solve_conic(objective: str, constraints: str) -> str:
     return result
 
 
-def solve_geometric(objective: str, constraints: str) -> str:
+def solve_geometric(
+    objective: str,
+    constraints: str,
+    method: Optional[str] = None,
+    max_iter: Optional[int] = None,
+    tolerance: Optional[float] = None,
+) -> str:
     """Solve a geometric program using CVXPY."""
 
     var_names = set(re.findall(r"[a-zA-Z]\w*", objective))
@@ -256,7 +335,21 @@ def solve_geometric(objective: str, constraints: str) -> str:
             constr.append(lhs_expr == float(rhs.strip()))
 
     prob = cp.Problem(cp.Minimize(objective_expr), constr)
-    prob.solve(gp=True)
+
+    solver_name = (method or "ECOS").upper()
+    if solver_name not in {"ECOS", "SCS"}:
+        raise ValueError(f"Unsupported method '{method}'")
+    solve_kwargs = {}
+    if max_iter is not None:
+        solve_kwargs["max_iters"] = int(max_iter)
+    if tolerance is not None:
+        if solver_name == "SCS":
+            solve_kwargs["eps"] = float(tolerance)
+        else:
+            solve_kwargs["abstol"] = float(tolerance)
+            solve_kwargs["reltol"] = float(tolerance)
+
+    prob.solve(gp=True, solver=solver_name, **solve_kwargs)
 
     if prob.status == cp.OPTIMAL:
         result = f"Status: {prob.status}\n"

--- a/templates/conic_program.html
+++ b/templates/conic_program.html
@@ -32,6 +32,15 @@
         <label for="constraints">Constraints (one per line):</label>
         <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., 1,0,0 <= 5\nsoc:1,0;0,1|0,0|1">{{ constraints or '' }}</textarea>
 
+        <label for="method">Method (optional):</label>
+        <input type="text" id="method" name="method" placeholder="e.g., SCS" value="{{ method or '' }}">
+
+        <label for="max_iter">Max Iterations (optional):</label>
+        <input type="number" id="max_iter" name="max_iter" value="{{ max_iter or '' }}">
+
+        <label for="tolerance">Tolerance (optional):</label>
+        <input type="number" step="any" id="tolerance" name="tolerance" value="{{ tolerance or '' }}">
+
         <input type="submit" value="Solve">
     </form>
 

--- a/templates/geometric_program.html
+++ b/templates/geometric_program.html
@@ -32,6 +32,15 @@
         <label for="constraints">Constraints (one per line):</label>
         <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., x * y <= 1">{{ constraints or '' }}</textarea>
 
+        <label for="method">Method (optional):</label>
+        <input type="text" id="method" name="method" placeholder="e.g., ECOS" value="{{ method or '' }}">
+
+        <label for="max_iter">Max Iterations (optional):</label>
+        <input type="number" id="max_iter" name="max_iter" value="{{ max_iter or '' }}">
+
+        <label for="tolerance">Tolerance (optional):</label>
+        <input type="number" step="any" id="tolerance" name="tolerance" value="{{ tolerance or '' }}">
+
         <input type="submit" value="Solve">
     </form>
 

--- a/templates/linear_program.html
+++ b/templates/linear_program.html
@@ -38,7 +38,16 @@
         
         <label for="constraints">Constraints (one per line):</label>
         <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., x + y <= 10&#10;x >= 0&#10;y >= 0">{{ constraints or '' }}</textarea>
-        
+
+        <label for="method">Method (optional):</label>
+        <input type="text" id="method" name="method" placeholder="e.g., cbc" value="{{ method or '' }}">
+
+        <label for="max_iter">Max Iterations (optional):</label>
+        <input type="number" id="max_iter" name="max_iter" value="{{ max_iter or '' }}">
+
+        <label for="tolerance">Tolerance (optional):</label>
+        <input type="number" step="any" id="tolerance" name="tolerance" value="{{ tolerance or '' }}">
+
         <input type="submit" value="Solve">
     </form>
 

--- a/templates/quadratic_program.html
+++ b/templates/quadratic_program.html
@@ -39,7 +39,16 @@
         
         <label for="constraints">Constraints (one per line):</label>
         <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., x + y <= 10&#10;x >= 0&#10;y >= 0">{{ constraints or '' }}</textarea>
-        
+
+        <label for="method">Method (optional):</label>
+        <input type="text" id="method" name="method" placeholder="e.g., ECOS" value="{{ method or '' }}">
+
+        <label for="max_iter">Max Iterations (optional):</label>
+        <input type="number" id="max_iter" name="max_iter" value="{{ max_iter or '' }}">
+
+        <label for="tolerance">Tolerance (optional):</label>
+        <input type="number" step="any" id="tolerance" name="tolerance" value="{{ tolerance or '' }}">
+
         <input type="submit" value="Solve">
     </form>
 

--- a/templates/semidefinite_program.html
+++ b/templates/semidefinite_program.html
@@ -33,6 +33,15 @@
         <label for="constraints">Constraints (one per line):</label>
         <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., 1,0;0,1 <= 1">{{ constraints or '' }}</textarea>
 
+        <label for="method">Method (optional):</label>
+        <input type="text" id="method" name="method" placeholder="e.g., SCS" value="{{ method or '' }}">
+
+        <label for="max_iter">Max Iterations (optional):</label>
+        <input type="number" id="max_iter" name="max_iter" value="{{ max_iter or '' }}">
+
+        <label for="tolerance">Tolerance (optional):</label>
+        <input type="number" step="any" id="tolerance" name="tolerance" value="{{ tolerance or '' }}">
+
         <input type="submit" value="Solve">
     </form>
 


### PR DESCRIPTION
## Summary
- allow specifying solver `method`, `max_iter`, and `tolerance` in solver functions
- pass new options through FastAPI routes and expose form fields
- document available solver parameters in README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846c37ba1ac832aa15092e81d58cdde