### PR TITLE
Add tutorial steps and quiz

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,12 @@ The app provides educational content on:
 ## How to Use the App
 
 1. Navigate to the home page for an introduction to Convex Optimization.
-2. Choose between the Linear Programming or Quadratic Programming solver.
-3. Input your problem:
+2. Follow the interactive tutorial at `/tutorial/step/1` for a guided walkthrough.
+3. Choose between the Linear Programming or Quadratic Programming solver.
+4. Input your problem:
    - For LP: Enter the coefficients of your objective function and constraints.
    - For QP: Provide the quadratic and linear terms of your objective function and linear constraints.
-4. Click "Solve" to get the optimal solution and interpretation.
+5. Click "Solve" to get the optimal solution and interpretation.
 
 ## Installation and Setup
 

--- a/routes.py
+++ b/routes.py
@@ -18,6 +18,20 @@ from visualize import (
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
 
+# Prefilled example problems used in the tutorial steps
+TUTORIAL_EXERCISES: dict[int, dict[str, str]] = {
+    1: {
+        "type": "linear_program",
+        "objective": "3x + 2y",
+        "constraints": "x + y <= 4\nx >= 0\ny >= 0",
+    },
+    2: {
+        "type": "quadratic_program",
+        "objective": "x^2 + y^2 + x",
+        "constraints": "x + y >= 1\nx >= 0\ny >= 0",
+    },
+}
+
 
 def load_problems() -> list[dict]:
     """Load example problems from the ``problems`` directory."""
@@ -41,6 +55,16 @@ def load_problems() -> list[dict]:
     return problems
 
 
+def load_quiz_questions() -> list[dict]:
+    """Load tutorial quiz questions from ``tutorial/quiz.yaml``."""
+    path = os.path.join("tutorial", "quiz.yaml")
+    if not os.path.exists(path):
+        return []
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return data.get("questions", []) if isinstance(data, dict) else []
+
+
 @router.get("/", response_class=HTMLResponse)
 async def root(request: Request) -> HTMLResponse:
     """Render the homepage with links to optimization problems."""
@@ -62,6 +86,89 @@ async def problem_library(
     return templates.TemplateResponse(
         "problem_library.html",
         {"request": request, "problems": problems, "selected": selected},
+    )
+
+
+@router.get("/tutorial/step/{step}", response_class=HTMLResponse)
+async def tutorial_step_get(request: Request, step: int) -> HTMLResponse:
+    """Render a tutorial step with a prefilled example problem."""
+    exercise = TUTORIAL_EXERCISES.get(step)
+    if not exercise:
+        return HTMLResponse("Step not found", status_code=404)
+    return templates.TemplateResponse(
+        f"tutorial/step{step}.html",
+        {
+            "request": request,
+            "objective": exercise["objective"],
+            "constraints": exercise["constraints"],
+        },
+    )
+
+
+@router.post("/tutorial/step/{step}", response_class=HTMLResponse)
+async def tutorial_step_post(
+    request: Request,
+    step: int,
+    objective: str = Form(...),
+    constraints: str = Form(...),
+) -> HTMLResponse:
+    """Solve the exercise for the given tutorial step."""
+    exercise = TUTORIAL_EXERCISES.get(step)
+    if not exercise:
+        return HTMLResponse("Step not found", status_code=404)
+    try:
+        if exercise["type"] == "linear_program":
+            result = solve_lp(objective, constraints)
+        elif exercise["type"] == "quadratic_program":
+            result = solve_qp(objective, constraints)
+        else:
+            result = "Unsupported exercise"
+    except Exception as exc:  # noqa: BLE001
+        result = f"An error occurred: {exc}"
+    return templates.TemplateResponse(
+        f"tutorial/step{step}.html",
+        {
+            "request": request,
+            "objective": objective,
+            "constraints": constraints,
+            "result": result,
+        },
+    )
+
+
+@router.get("/tutorial/quiz", response_class=HTMLResponse)
+async def tutorial_quiz_get(request: Request, q: int = Query(0)) -> HTMLResponse:
+    """Display a quiz question from the tutorial."""
+    questions = load_quiz_questions()
+    if q < 0 or q >= len(questions):
+        return HTMLResponse("Question not found", status_code=404)
+    question = questions[q]
+    return templates.TemplateResponse(
+        "tutorial/quiz.html",
+        {"request": request, "question": question, "index": q},
+    )
+
+
+@router.post("/tutorial/quiz", response_class=HTMLResponse)
+async def tutorial_quiz_post(
+    request: Request, q: int = Form(...), answer: str = Form(...)
+) -> HTMLResponse:
+    """Check the submitted answer and show whether it is correct."""
+    questions = load_quiz_questions()
+    if q < 0 or q >= len(questions):
+        return HTMLResponse("Question not found", status_code=404)
+    question = questions[q]
+    correct = answer.strip() == question.get("answer")
+    return templates.TemplateResponse(
+        "tutorial/quiz.html",
+        {
+            "request": request,
+            "question": question,
+            "index": q,
+            "answered": True,
+            "correct": correct,
+            "given": answer,
+        },
     )
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,6 +46,8 @@
         <p>Plot feasible regions and objective contours for small problems.</p>
         <a href="/problems" class="problem-link">Problem Library</a>
         <p>Browse sample problems and load them into a solver.</p>
+        <a href="/tutorial/step/1" class="problem-link">Tutorial</a>
+        <p>Follow a step-by-step walkthrough with quizzes.</p>
         <a href="/gradient_descent" class="problem-link">Gradient Descent Animation</a>
         <p>See a step-by-step visualization of the algorithm.</p>
     </section>

--- a/templates/tutorial/quiz.html
+++ b/templates/tutorial/quiz.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tutorial Quiz</title>
+    <style>
+        body { font-family: Arial, sans-serif; line-height: 1.6; padding: 20px; max-width: 800px; margin: 0 auto; }
+        h1 { color: #333; }
+        form { background-color: #f0f0f0; padding: 20px; border-radius: 5px; }
+        input[type="submit"] { background-color: #4CAF50; color: white; padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer; }
+        input[type="submit"]:hover { background-color: #45a049; }
+    </style>
+</head>
+<body>
+    <h1>Quiz</h1>
+    <p>{{ question.question }}</p>
+    <form action="/tutorial/quiz" method="post">
+        <input type="hidden" name="q" value="{{ index }}">
+        {% for opt in question.options %}
+        <label><input type="radio" name="answer" value="{{ opt }}" required> {{ opt }}</label><br>
+        {% endfor %}
+        <input type="submit" value="Submit">
+    </form>
+    {% if answered %}
+        {% if correct %}
+            <p><strong>Correct!</strong></p>
+        {% else %}
+            <p><strong>Incorrect.</strong> Correct answer: {{ question.answer }}</p>
+        {% endif %}
+    {% endif %}
+    <p><a href="/">Home</a></p>
+</body>
+</html>

--- a/templates/tutorial/step1.html
+++ b/templates/tutorial/step1.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tutorial Step 1 - Linear Programming</title>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; line-height: 1.6; padding: 20px; max-width: 800px; margin: 0 auto; }
+        h1, h2 { color: #333; }
+        form { background-color: #f0f0f0; padding: 20px; border-radius: 5px; }
+        label { display: block; margin-bottom: 5px; }
+        input[type="text"], textarea { width: 100%; padding: 8px; margin-bottom: 10px; border: 1px solid #ddd; border-radius: 4px; }
+        input[type="submit"] { background-color: #4CAF50; color: white; padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer; }
+        input[type="submit"]:hover { background-color: #45a049; }
+        #result { margin-top: 20px; padding: 10px; background-color: #e0e0e0; border-radius: 5px; }
+    </style>
+</head>
+<body>
+    <h1>Step 1: Linear Programming Basics</h1>
+    <p>This step introduces linear programming, where both the objective function and constraints are linear.</p>
+    <form action="/tutorial/step/1" method="post">
+        <label for="objective">Objective Function:</label>
+        <input type="text" id="objective" name="objective" required value="{{ objective }}">
+        <label for="constraints">Constraints (one per line):</label>
+        <textarea id="constraints" name="constraints" rows="5" required>{{ constraints }}</textarea>
+        <input type="submit" value="Solve">
+    </form>
+    {% if result %}
+    <div id="result">
+        <h2>Result:</h2>
+        <pre>{{ result }}</pre>
+    </div>
+    {% endif %}
+    <p><a href="/tutorial/step/2">Next Step</a> | <a href="/">Home</a></p>
+</body>
+</html>

--- a/templates/tutorial/step2.html
+++ b/templates/tutorial/step2.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tutorial Step 2 - Quadratic Programming</title>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; line-height: 1.6; padding: 20px; max-width: 800px; margin: 0 auto; }
+        h1, h2 { color: #333; }
+        form { background-color: #f0f0f0; padding: 20px; border-radius: 5px; }
+        label { display: block; margin-bottom: 5px; }
+        input[type="text"], textarea { width: 100%; padding: 8px; margin-bottom: 10px; border: 1px solid #ddd; border-radius: 4px; }
+        input[type="submit"] { background-color: #4CAF50; color: white; padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer; }
+        input[type="submit"]:hover { background-color: #45a049; }
+        #result { margin-top: 20px; padding: 10px; background-color: #e0e0e0; border-radius: 5px; }
+    </style>
+</head>
+<body>
+    <h1>Step 2: Quadratic Programming</h1>
+    <p>This step demonstrates quadratic programming with a quadratic objective.</p>
+    <form action="/tutorial/step/2" method="post">
+        <label for="objective">Objective Function:</label>
+        <input type="text" id="objective" name="objective" required value="{{ objective }}">
+        <label for="constraints">Constraints (one per line):</label>
+        <textarea id="constraints" name="constraints" rows="5" required>{{ constraints }}</textarea>
+        <input type="submit" value="Solve">
+    </form>
+    {% if result %}
+    <div id="result">
+        <h2>Result:</h2>
+        <pre>{{ result }}</pre>
+    </div>
+    {% endif %}
+    <p><a href="/tutorial/quiz">Quiz</a> | <a href="/">Home</a></p>
+</body>
+</html>

--- a/tutorial/quiz.yaml
+++ b/tutorial/quiz.yaml
@@ -1,0 +1,7 @@
+questions:
+  - question: "What property guarantees that a local optimum is also a global optimum in convex optimization?"
+    options:
+      - "Convex objective and feasible set"
+      - "Non-linear constraints"
+      - "Random initialization"
+    answer: "Convex objective and feasible set"


### PR DESCRIPTION
## Summary
- implement interactive tutorial steps
- prefill example problems for each tutorial page
- add simple quiz backed by YAML
- link to tutorial from the home page and README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cvxpy')*

------
https://chatgpt.com/codex/tasks/task_e_6846c37d9488832ab052d7312e188731