### PR TITLE
Fix README to clarify cross-term support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Navigate to `/visualize` to try it out.
 
 ### 4. Educational Content
 
-Cross terms in the objective function (e.g., `xy`) are currently unsupported.
+Cross terms in quadratic objectives (e.g., `xy`) are now supported.
 
 ### 3. Educational Content
 <!-- main -->


### PR DESCRIPTION
## Summary
- update README to mention support for cross-terms like `xy`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846cd534a7c832a9ed0866f1e9d71f6