### PR TITLE
Fix unused imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,8 +8,6 @@ from fastapi import FastAPI, Request, Form
 from fastapi.templating import Jinja2Templates
 from fastapi.responses import HTMLResponse
 # codex/add-route-for-2d-plots-visualization
-from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel
 import uvicorn
 # main
 import pulp
@@ -18,7 +16,6 @@ from parser import parse_polynomial, extract_linear_coeffs, extract_quadratic_te
 import sympy as sp
 import numpy as np
 import re
-import numpy as np
 import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt

--- a/solvers.py
+++ b/solvers.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Tuple
 
 import cvxpy as cp
 import pulp
-import numpy as np
 import re
 
 from parser import parse_matrix, parse_vector, parse_posynomial

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,4 +1,3 @@
-import pytest
 from solvers import parse_expression
 
 def test_positive_negative_coefficients():


### PR DESCRIPTION
## Summary
- clean up flagged unused imports in app, solvers, and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'solvers')*

------
https://chatgpt.com/codex/tasks/task_e_6846cd521848832ab4fa1e8c602120a9