### PR TITLE
Clean up test imports

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,9 +1,6 @@
 import os
 import sys
 
-import os
-import sys
-import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 


### PR DESCRIPTION
## Summary
- remove unused `pytest`, `os`, and `sys` imports from `tests/test_parser.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ValueError too many values to unpack)*

------
https://chatgpt.com/codex/tasks/task_e_684709065144832a8baa9909b2326481