### PR TITLE
Fix FastAPI/Starlette compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-anyio==4.4.0
+anyio>=3.7.1,<4.0.0
 beautifulsoup4==4.12.3
 certifi==2024.8.30
 clarabel==0.9.0
@@ -38,7 +38,8 @@ six==1.16.0
 sniffio==1.3.1
 soupsieve==2.6
 sqlite-minutils==3.37.0.post3
-starlette==0.38.5
+fastapi==0.104.1
+starlette>=0.27.0,<0.28.0
 uvicorn==0.30.6
 watchfiles==0.24.0
 websockets==13.0.1


### PR DESCRIPTION
## Summary
- ensure FastAPI is installed
- pin Starlette to a version supported by FastAPI
- adjust anyio constraint for compatibility

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68481f60b424832a8a0808c8ab313a96