### PR TITLE
Expand route and solver test coverage

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,3 +37,19 @@ def test_api_quadratic_program():
     data = response.json()
     assert data.get("status") == "ok"
     assert "result" in data
+
+from app import app as full_app
+full_client = TestClient(full_app)
+
+def test_visualize_route_generates_plot():
+    response = full_client.post(
+        "/visualize",
+        data={"objective": "x", "constraints": "x >= 0"},
+    )
+    assert response.status_code == 200
+    assert "data:image/png;base64" in response.text
+
+def test_benchmark_route_displays_table():
+    response = client.get("/benchmark")
+    assert response.status_code == 200
+    assert "<table" in response.text

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -23,3 +23,20 @@ def test_missing_var_multiple_constraints():
     values = {line.split("=")[0].strip(): float(line.split("=")[1])
               for line in re.findall(r"^\w+ = [\d.-]+", result, re.MULTILINE)}
     assert "y" in values
+
+from solvers import solve_sdp, solve_conic, solve_geometric
+
+
+def test_solve_sdp_basic():
+    result = solve_sdp("1,0;0,1", "1,0;0,1 >= 1")
+    assert "Status: optimal" in result
+
+
+def test_solve_conic_basic():
+    result = solve_conic("1,1", "soc:1,0;0,1|0,0|1")
+    assert "Status: optimal" in result
+
+
+def test_solve_geometric_basic():
+    result = solve_geometric("x*y", "x*y >= 1\nx >= 1\ny >= 1")
+    assert "Status: optimal" in result


### PR DESCRIPTION
## Summary
- ensure compatibility by installing a newer FastAPI version
- test `/visualize` image output and `/benchmark` results table
- add SDP, conic, and geometric solver tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68481f620f68832aa543754118dcae00