### PR TITLE
Add interactive Plotly visualizations

### DIFF
--- a/templates/visualize.html
+++ b/templates/visualize.html
@@ -26,22 +26,36 @@
         <label for="constraints">Constraints (one per line):</label>
         <textarea id="constraints" name="constraints" rows="5" required placeholder="e.g., x + y <= 10&#10;x >= 0&#10;y >= 0"></textarea>
 
-        <label><input type="checkbox" name="animate" value="true"> Animate Gradient Descent</label>
+        <label for="algorithm">Animation Algorithm:</label>
+        <select id="algorithm" name="algorithm">
+            <option value="">None</option>
+            <option value="gradient_descent">Gradient Descent</option>
+            <option value="interior_point">Interior Point</option>
+            <option value="simplex">Simplex</option>
+            <option value="feasible_region">Feasible Region</option>
+        </select>
 
         <input type="submit" value="Visualize">
     </form>
 
-    {% if plot_data %}
+    {% if plot_html %}
     <div id="plot">
-        <h2>Visualization:</h2>
-        <img src="data:image/png;base64,{{ plot_data }}" alt="Visualization Plot">
+        <h2>Feasible Region:</h2>
+        {{ plot_html | safe }}
     </div>
     {% endif %}
 
-    {% if animation_data %}
+    {% if surface_html %}
+    <div id="surface">
+        <h2>Objective Surface:</h2>
+        {{ surface_html | safe }}
+    </div>
+    {% endif %}
+
+    {% if animation_html %}
     <div id="animation">
         <h2>Algorithm Progress:</h2>
-        <img src="data:image/gif;base64,{{ animation_data }}" alt="Algorithm Animation">
+        {{ animation_html | safe }}
     </div>
     {% endif %}
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -47,7 +47,7 @@ def test_visualize_route_generates_plot():
         data={"objective": "x", "constraints": "x >= 0"},
     )
     assert response.status_code == 200
-    assert "data:image/png;base64" in response.text
+    assert "Plotly.newPlot" in response.text
 
 def test_benchmark_route_displays_table():
     response = client.get("/benchmark")

--- a/visualize.py
+++ b/visualize.py
@@ -23,6 +23,25 @@ def _evaluate_expression(terms: List[Tuple[float, str]], X: np.ndarray, Y: np.nd
     return Z
 
 
+def _gradient_terms(terms: List[Tuple[float, str]], point: np.ndarray) -> np.ndarray:
+    """Compute gradient of a parsed expression at a point."""
+    grad = np.zeros(2)
+    x, y = point
+    for coef, var in terms:
+        if var.endswith("^2"):
+            base = var[:-2]
+            if base == "x":
+                grad[0] += 2 * coef * x
+            elif base == "y":
+                grad[1] += 2 * coef * y
+        else:
+            if var == "x":
+                grad[0] += coef
+            elif var == "y":
+                grad[1] += coef
+    return grad
+
+
 def plot_linear_program(objective: str, constraints: str) -> go.Figure:
     """Generate a 2D plot of the feasible region and objective contours."""
     obj_terms = parse_expression(objective)
@@ -152,5 +171,239 @@ def gradient_descent_animation(objective: str, steps: int = 30, lr: float = 0.1)
                 buttons=[dict(label="Play", method="animate", args=[None])],
             )
         ],
+    )
+    return fig
+
+
+def plot_3d_surface(expression: str) -> go.Figure:
+    """Generate a generic 3D surface plot for a polynomial expression."""
+    terms = parse_expression(expression)
+    x = np.linspace(-5, 5, 100)
+    y = np.linspace(-5, 5, 100)
+    X, Y = np.meshgrid(x, y)
+    Z = _evaluate_expression(terms, X, Y)
+    fig = go.Figure(data=[go.Surface(x=x, y=y, z=Z, colorscale="Viridis")])
+    fig.update_layout(
+        title="3D Surface",
+        scene=dict(xaxis_title="x", yaxis_title="y", zaxis_title="f(x,y)"),
+    )
+    return fig
+
+
+def feasible_region_animation(objective: str, constraints: str) -> go.Figure:
+    """Animate the construction of the feasible region."""
+    obj_terms = parse_expression(objective)
+    x = np.linspace(-5, 5, 200)
+    y = np.linspace(-5, 5, 200)
+    X, Y = np.meshgrid(x, y)
+    Z = _evaluate_expression(obj_terms, X, Y)
+
+    lines = [c for c in constraints.splitlines() if c.strip()]
+    masks = []
+    mask = np.ones_like(X, dtype=bool)
+    for line in lines:
+        if "<=" in line:
+            lhs, rhs = line.split("<=")
+            lhs_terms = parse_expression(lhs)
+            lhs_val = _evaluate_expression(lhs_terms, X, Y)
+            mask &= lhs_val <= float(rhs.strip())
+        elif ">=" in line:
+            lhs, rhs = line.split(">=")
+            lhs_terms = parse_expression(lhs)
+            lhs_val = _evaluate_expression(lhs_terms, X, Y)
+            mask &= lhs_val >= float(rhs.strip())
+        masks.append(mask.copy())
+
+    contour = go.Contour(x=x, y=y, z=Z, contours=dict(showlabels=True), showscale=False)
+    frames = []
+    for m in masks:
+        frames.append(
+            go.Frame(
+                data=[
+                    contour,
+                    go.Heatmap(
+                        x=x,
+                        y=y,
+                        z=m.astype(int),
+                        showscale=False,
+                        opacity=0.3,
+                        colorscale=[[0, "rgba(0,0,0,0)"], [1, "rgba(0,200,0,0.4)"]],
+                    ),
+                ]
+            )
+        )
+
+    fig = go.Figure(data=frames[0].data, frames=frames)
+    fig.update_layout(
+        title="Feasible Region Animation",
+        xaxis_title="x",
+        yaxis_title="y",
+        updatemenus=[
+            dict(
+                type="buttons",
+                showactive=False,
+                buttons=[dict(label="Play", method="animate", args=[None])],
+            )
+        ],
+    )
+    return fig
+
+
+def interior_point_animation(objective: str, constraints: str, steps: int = 20) -> go.Figure:
+    """Simple interior-point style animation for demonstration."""
+    obj_terms = parse_expression(objective)
+    cons = []
+    for c in constraints.splitlines():
+        if not c.strip():
+            continue
+        if "<=" in c:
+            lhs, rhs = c.split("<=")
+            cons.append((parse_expression(lhs), "<=", float(rhs.strip())))
+        elif ">=" in c:
+            lhs, rhs = c.split(">=")
+            cons.append((parse_expression(lhs), ">=", float(rhs.strip())))
+
+    x = np.linspace(-5, 5, 200)
+    y = np.linspace(-5, 5, 200)
+    X, Y = np.meshgrid(x, y)
+    Z = _evaluate_expression(obj_terms, X, Y)
+
+    mask = np.ones_like(X, dtype=bool)
+    for t, op, val in cons:
+        vals = _evaluate_expression(t, X, Y)
+        if op == "<=":
+            mask &= vals <= val
+        else:
+            mask &= vals >= val
+
+    point = np.array([0.0, 0.0])
+    path = [point.copy()]
+    lr = 0.05
+    t = 1.0
+    for _ in range(steps):
+        grad = _gradient_terms(obj_terms, point)
+        barrier = np.zeros(2)
+        for terms, op, val in cons:
+            g_val = _evaluate_expression(terms, np.array([[point[0]]]), np.array([[point[1]]]))[0, 0]
+            diff = g_val - val if op == "<=" else val - g_val
+            grad_g = _gradient_terms(terms, point)
+            barrier += grad_g / (diff if diff != 0 else 1e-6)
+        point = point - lr * (grad + t * barrier)
+        path.append(point.copy())
+        t *= 0.9
+
+    path = np.array(path)
+    contour = go.Contour(x=x, y=y, z=Z, contours=dict(showlabels=True), showscale=False)
+    region = go.Heatmap(
+        x=x,
+        y=y,
+        z=mask.astype(int),
+        showscale=False,
+        opacity=0.3,
+        colorscale=[[0, "rgba(0,0,0,0)"], [1, "rgba(0,200,0,0.4)"]],
+    )
+    frames = [go.Frame(data=[contour, region, go.Scatter(x=path[:1,0], y=path[:1,1], mode="markers+lines", line=dict(color="red"))])]
+    for i in range(1, len(path)):
+        frames.append(
+            go.Frame(
+                data=[
+                    contour,
+                    region,
+                    go.Scatter(x=path[: i + 1, 0], y=path[: i + 1, 1], mode="markers+lines", line=dict(color="red")),
+                ]
+            )
+        )
+    fig = go.Figure(data=frames[0].data, frames=frames)
+    fig.update_layout(
+        title="Interior Point Animation",
+        xaxis_title="x",
+        yaxis_title="y",
+        updatemenus=[dict(type="buttons", showactive=False, buttons=[dict(label="Play", method="animate", args=[None])])],
+    )
+    return fig
+
+
+def simplex_animation(objective: str, constraints: str) -> go.Figure:
+    """Naive simplex-style animation using polygon vertices."""
+    obj_terms = parse_expression(objective)
+    lines = [c for c in constraints.splitlines() if c.strip()]
+
+    def parse_coeffs(expr: str) -> tuple[float, float]:
+        terms = parse_expression(expr)
+        a = b = 0.0
+        for coef, var in terms:
+            if var == "x":
+                a += coef
+            elif var == "y":
+                b += coef
+        return a, b
+
+    coeffs = []
+    for c in lines:
+        if "<=" in c:
+            lhs, rhs = c.split("<=")
+            a, b = parse_coeffs(lhs)
+            coeffs.append((a, b, float(rhs.strip()), "<="))
+        elif ">=" in c:
+            lhs, rhs = c.split(">=")
+            a, b = parse_coeffs(lhs)
+            coeffs.append((a, b, float(rhs.strip()), ">="))
+
+    vertices = []
+    for i in range(len(coeffs)):
+        for j in range(i + 1, len(coeffs)):
+            a1, b1, c1, _ = coeffs[i]
+            a2, b2, c2, _ = coeffs[j]
+            det = a1 * b2 - a2 * b1
+            if det == 0:
+                continue
+            px = (c1 * b2 - c2 * b1) / det
+            py = (a1 * c2 - a2 * c1) / det
+            feasible = True
+            for a, b, c, op in coeffs:
+                val = a * px + b * py
+                if op == "<=" and val > c + 1e-6:
+                    feasible = False
+                    break
+                if op == ">=" and val < c - 1e-6:
+                    feasible = False
+                    break
+            if feasible:
+                vertices.append((px, py))
+
+    if not vertices:
+        raise ValueError("No feasible region")
+
+    vals = [
+        _evaluate_expression(obj_terms, np.array([[vx]]), np.array([[vy]]))[0, 0]
+        for vx, vy in vertices
+    ]
+    order = np.argsort(vals)
+    path = np.array([vertices[i] for i in order])
+
+    x = np.linspace(-5, 5, 200)
+    y = np.linspace(-5, 5, 200)
+    X, Y = np.meshgrid(x, y)
+    Z = _evaluate_expression(obj_terms, X, Y)
+    mask = np.ones_like(X, dtype=bool)
+    for a, b, c, op in coeffs:
+        vals = a * X + b * Y
+        if op == "<=":
+            mask &= vals <= c
+        else:
+            mask &= vals >= c
+
+    contour = go.Contour(x=x, y=y, z=Z, contours=dict(showlabels=True), showscale=False)
+    region = go.Heatmap(x=x, y=y, z=mask.astype(int), showscale=False, opacity=0.3, colorscale=[[0, "rgba(0,0,0,0)"], [1, "rgba(0,200,0,0.4)"]])
+    frames = [go.Frame(data=[contour, region, go.Scatter(x=path[:1,0], y=path[:1,1], mode="markers+lines", line=dict(color="red"))])]
+    for i in range(1, len(path)):
+        frames.append(go.Frame(data=[contour, region, go.Scatter(x=path[: i + 1, 0], y=path[: i + 1, 1], mode="markers+lines", line=dict(color="red"))]))
+
+    fig = go.Figure(data=frames[0].data, frames=frames)
+    fig.update_layout(
+        title="Simplex Animation",
+        xaxis_title="x",
+        yaxis_title="y",
+        updatemenus=[dict(type="buttons", showactive=False, buttons=[dict(label="Play", method="animate", args=[None])])],
     )
     return fig


### PR DESCRIPTION
## Summary
- extend `visualize.py` with 3D surface plotting, feasible-region animation, and algorithm animations
- update `app.py` to use Plotly figures and new animation options
- switch `visualize.html` to render Plotly interactive plots
- adjust API tests for Plotly output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848307487d4832ab861cc23c8ab851f