### PR TITLE
Expand problem library and recursive load

### DIFF
--- a/problems/case_studies/portfolio.json
+++ b/problems/case_studies/portfolio.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "Portfolio Optimization",
+    "type": "quadratic_program",
+    "description": "Allocate investment to minimize variance with a required return.",
+    "objective": "0.5x^2 + 0.5y^2",
+    "constraints": [
+      "x + y = 1",
+      "x >= 0",
+      "y >= 0"
+    ]
+  }
+]

--- a/problems/case_studies/transport.yaml
+++ b/problems/case_studies/transport.yaml
@@ -1,0 +1,10 @@
+- name: Transportation LP
+  type: linear_program
+  description: "Classic transportation example with shipping costs."
+  objective: "4x + 5y + 6z"
+  constraints:
+    - "x + y >= 50"
+    - "y + z >= 60"
+    - "x >= 0"
+    - "y >= 0"
+    - "z >= 0"

--- a/problems/examples.yaml
+++ b/problems/examples.yaml
@@ -34,3 +34,26 @@
     - "x*y >= 1"
     - "x >= 1"
     - "y >= 1"
+- name: Factory Production
+  type: linear_program
+  description: "Maximize profit given resource limits."
+  objective: "-5x - 3y"
+  constraints:
+    - "2x + y <= 100"
+    - "x + y <= 80"
+    - "x >= 0"
+    - "y >= 0"
+- name: Portfolio QP
+  type: quadratic_program
+  description: "Minimize variance with return constraint."
+  objective: "x^2 + y^2"
+  constraints:
+    - "x + y = 1"
+    - "x >= 0"
+    - "y >= 0"
+- name: Cone Portfolio
+  type: conic_program
+  description: "Cone constraint on portfolio weights."
+  objective: "1,2"
+  constraints:
+    - "soc:1,1|0,0|1.5"

--- a/routes.py
+++ b/routes.py
@@ -43,24 +43,28 @@ TUTORIAL_EXERCISES: dict[int, dict[str, str]] = {
 
 
 def load_problems() -> list[dict]:
-    """Load example problems from the ``problems`` directory."""
-    problems = []
+    """Load example problems from YAML/JSON files under ``problems``."""
+    problems: list[dict] = []
     if not os.path.isdir("problems"):
         return problems
-    for fname in sorted(os.listdir("problems")):
-        path = os.path.join("problems", fname)
-        if fname.endswith((".yaml", ".yml")):
-            with open(path, "r", encoding="utf-8") as f:
-                data = yaml.safe_load(f)
-        elif fname.endswith(".json"):
-            with open(path, "r", encoding="utf-8") as f:
-                data = json.load(f)
-        else:
-            continue
-        if isinstance(data, list):
-            problems.extend(data)
-        else:
-            problems.append(data)
+
+    for root, _dirs, files in os.walk("problems"):
+        for fname in sorted(files):
+            path = os.path.join(root, fname)
+            if fname.endswith((".yaml", ".yml")):
+                with open(path, "r", encoding="utf-8") as f:
+                    data = yaml.safe_load(f)
+            elif fname.endswith(".json"):
+                with open(path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+            else:
+                continue
+
+            if isinstance(data, list):
+                problems.extend(data)
+            else:
+                problems.append(data)
+
     return problems
 
 

--- a/templates/problem_library.html
+++ b/templates/problem_library.html
@@ -18,7 +18,10 @@
     <h1>Problem Library</h1>
     <ul class="problem-list">
         {% for p in problems %}
-        <li><a href="/problems?problem={{ p.name | urlencode }}">{{ p.name }}</a></li>
+        <li>
+            <a href="/problems?problem={{ p.name | urlencode }}">{{ p.name }}</a>
+            - {{ p.description }}
+        </li>
         {% endfor %}
     </ul>
 


### PR DESCRIPTION
## Summary
- load sample problems recursively from YAML/JSON files
- extend problem list display with short descriptions
- add more example problems
- include case study folder with transportation and portfolio examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68482fa7ccc8832ab4440fab04ea9e46