### PR TITLE
Add algorithm option to solvers and UI

### DIFF
--- a/templates/conic_program.html
+++ b/templates/conic_program.html
@@ -35,6 +35,9 @@
         <label for="method">Method (optional):</label>
         <input type="text" id="method" name="method" placeholder="e.g., SCS" value="{{ method or '' }}">
 
+        <label for="algorithm">Algorithm (optional):</label>
+        <input type="text" id="algorithm" name="algorithm" placeholder="e.g., barrier" value="{{ algorithm or '' }}">
+
         <label for="max_iter">Max Iterations (optional):</label>
         <input type="number" id="max_iter" name="max_iter" value="{{ max_iter or '' }}">
 

--- a/templates/geometric_program.html
+++ b/templates/geometric_program.html
@@ -35,6 +35,9 @@
         <label for="method">Method (optional):</label>
         <input type="text" id="method" name="method" placeholder="e.g., ECOS" value="{{ method or '' }}">
 
+        <label for="algorithm">Algorithm (optional):</label>
+        <input type="text" id="algorithm" name="algorithm" placeholder="e.g., successive" value="{{ algorithm or '' }}">
+
         <label for="max_iter">Max Iterations (optional):</label>
         <input type="number" id="max_iter" name="max_iter" value="{{ max_iter or '' }}">
 

--- a/templates/linear_program.html
+++ b/templates/linear_program.html
@@ -42,6 +42,9 @@
         <label for="method">Method (optional):</label>
         <input type="text" id="method" name="method" placeholder="e.g., cbc" value="{{ method or '' }}">
 
+        <label for="algorithm">Algorithm (optional):</label>
+        <input type="text" id="algorithm" name="algorithm" placeholder="e.g., simplex" value="{{ algorithm or '' }}">
+
         <label for="max_iter">Max Iterations (optional):</label>
         <input type="number" id="max_iter" name="max_iter" value="{{ max_iter or '' }}">
 

--- a/templates/quadratic_program.html
+++ b/templates/quadratic_program.html
@@ -43,6 +43,9 @@
         <label for="method">Method (optional):</label>
         <input type="text" id="method" name="method" placeholder="e.g., ECOS" value="{{ method or '' }}">
 
+        <label for="algorithm">Algorithm (optional):</label>
+        <input type="text" id="algorithm" name="algorithm" placeholder="e.g., interior-point" value="{{ algorithm or '' }}">
+
         <label for="max_iter">Max Iterations (optional):</label>
         <input type="number" id="max_iter" name="max_iter" value="{{ max_iter or '' }}">
 

--- a/templates/semidefinite_program.html
+++ b/templates/semidefinite_program.html
@@ -36,6 +36,9 @@
         <label for="method">Method (optional):</label>
         <input type="text" id="method" name="method" placeholder="e.g., SCS" value="{{ method or '' }}">
 
+        <label for="algorithm">Algorithm (optional):</label>
+        <input type="text" id="algorithm" name="algorithm" placeholder="e.g., ADMM" value="{{ algorithm or '' }}">
+
         <label for="max_iter">Max Iterations (optional):</label>
         <input type="number" id="max_iter" name="max_iter" value="{{ max_iter or '' }}">
 


### PR DESCRIPTION
## Summary
- extend solver functions with `algorithm` parameter
- validate solver options in `routes.py`
- expose new algorithm field in HTML forms

## Testing
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68482fa88f20832a91d81d6c1122bdc0