### PR TITLE
Add solver API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,35 @@ The app provides educational content on:
    - For QP: Provide the quadratic and linear terms of your objective function and linear constraints.
 5. Click "Solve" to get the optimal solution and interpretation.
 
+## API Usage
+
+The application exposes solver endpoints that accept JSON payloads. Each request
+returns a response with `status` and `result` fields.
+
+Example request to solve a linear program:
+
+```bash
+curl -X POST http://localhost:8000/api/linear_program \
+     -H 'Content-Type: application/json' \
+     -d '{"objective": "x", "constraints": "x >= 1"}'
+```
+
+Available endpoints:
+
+- `POST /api/linear_program`
+- `POST /api/quadratic_program`
+- `POST /api/semidefinite_program`
+- `POST /api/conic_program`
+- `POST /api/geometric_program`
+
+All endpoints accept the following JSON keys:
+
+- `objective` – objective function or matrix/vector string
+- `constraints` – newline separated constraints
+- `method` *(optional)* – solver backend
+- `max_iter` *(optional)* – iteration limit
+- `tolerance` *(optional)* – solver tolerance
+
 ## Installation and Setup
 
 This project requires **Python 3.11**.

--- a/routes.py
+++ b/routes.py
@@ -390,6 +390,24 @@ async def sdp_post(
     )
 
 
+@router.post("/api/semidefinite_program")
+async def api_semidefinite_program(req: ProgramRequest) -> dict:
+    """Solve a semidefinite program and return JSON results."""
+    try:
+        result = solve_sdp(
+            req.objective,
+            req.constraints,
+            method=req.method,
+            max_iter=req.max_iter,
+            tolerance=req.tolerance,
+        )
+        status = "ok"
+    except Exception as exc:  # noqa: BLE001
+        result = f"An error occurred: {exc}"
+        status = "error"
+    return {"status": status, "result": result}
+
+
 @router.get("/conic_program", response_class=HTMLResponse)
 async def conic_get(
     request: Request,
@@ -445,6 +463,24 @@ async def conic_post(
     )
 
 
+@router.post("/api/conic_program")
+async def api_conic_program(req: ProgramRequest) -> dict:
+    """Solve a conic program and return JSON results."""
+    try:
+        result = solve_conic(
+            req.objective,
+            req.constraints,
+            method=req.method,
+            max_iter=req.max_iter,
+            tolerance=req.tolerance,
+        )
+        status = "ok"
+    except Exception as exc:  # noqa: BLE001
+        result = f"An error occurred: {exc}"
+        status = "error"
+    return {"status": status, "result": result}
+
+
 @router.get("/geometric_program", response_class=HTMLResponse)
 async def gp_get(
     request: Request,
@@ -498,6 +534,24 @@ async def gp_post(
             "tolerance": tolerance,
         },
     )
+
+
+@router.post("/api/geometric_program")
+async def api_geometric_program(req: ProgramRequest) -> dict:
+    """Solve a geometric program and return JSON results."""
+    try:
+        result = solve_geometric(
+            req.objective,
+            req.constraints,
+            method=req.method,
+            max_iter=req.max_iter,
+            tolerance=req.tolerance,
+        )
+        status = "ok"
+    except Exception as exc:  # noqa: BLE001
+        result = f"An error occurred: {exc}"
+        status = "error"
+    return {"status": status, "result": result}
 
 
 @router.get("/gradient_descent", response_class=HTMLResponse)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,6 +38,42 @@ def test_api_quadratic_program():
     assert data.get("status") == "ok"
     assert "result" in data
 
+
+def test_api_semidefinite_program():
+    payload = {
+        "objective": "1,0;0,1",
+        "constraints": "1,0;0,1 >= 1",
+    }
+    response = client.post("/api/semidefinite_program", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data.get("status") == "ok"
+    assert "result" in data
+
+
+def test_api_conic_program():
+    payload = {
+        "objective": "1,1",
+        "constraints": "soc:1,0;0,1|0,0|1",
+    }
+    response = client.post("/api/conic_program", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data.get("status") == "ok"
+    assert "result" in data
+
+
+def test_api_geometric_program():
+    payload = {
+        "objective": "x*y",
+        "constraints": "x*y >= 1\nx >= 1\ny >= 1",
+    }
+    response = client.post("/api/geometric_program", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data.get("status") == "ok"
+    assert "result" in data
+
 from app import app as full_app
 full_client = TestClient(full_app)
 


### PR DESCRIPTION
## Summary
- add REST endpoints for SDP, conic and geometric programs
- extend test coverage for new API routes
- document solver API usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68482faa08d4832a83795873c2bc2132