### PR TITLE
Add scalable benchmarking support

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import argparse
 import csv
 import time
+import random
 from typing import Any, Callable, Dict, List, Tuple
 
 import cvxpy as cp
 
 from solvers import parse_expression
 from routes import load_problems
+from jinja2 import Environment, FileSystemLoader
 
 
 # -------------------------
@@ -201,37 +203,96 @@ def _gp_problem(objective: str, constraints: str) -> cp.Problem:
     return cp.Problem(cp.Minimize(obj), constr)
 
 
-# Mapping problem types to solver functions
-SOLVERS: Dict[str, List[Callable[[str, str], Tuple[str, float, Any]]]] = {
-    "linear_program": [
-        _lp_with_pulp,
-        lambda o, c: _lp_with_cvxpy(o, c, "ECOS_BB"),
-    ],
-    "quadratic_program": [
-        lambda o, c: _qp_with_cvxpy(o, c, "OSQP"),
-        lambda o, c: _qp_with_cvxpy(o, c, "ECOS"),
-    ],
-    "semidefinite_program": [
-        lambda o, c: _generic_cvxpy(o, c, _sdp_problem, "SCS"),
-    ],
-    "conic_program": [
-        lambda o, c: _generic_cvxpy(o, c, _conic_problem, "SCS"),
-    ],
-    "geometric_program": [
-        lambda o, c: _generic_cvxpy(o, c, _gp_problem, "SCS", gp=True),
-    ],
+# -------------------------
+# Problem generation helpers
+# -------------------------
+
+def _generate_lp(n: int) -> tuple[str, str]:
+    """Generate a random dense linear program with ``n`` variables."""
+    objective = " + ".join(f"{random.randint(1,5)}x{i}" for i in range(n))
+    constraints = []
+    for j in range(n):
+        lhs = " + ".join(f"{random.randint(1,5)}x{i}" for i in range(n))
+        rhs = random.randint(n, 2 * n)
+        constraints.append(f"{lhs} >= {rhs}")
+    return objective, "\n".join(constraints)
+
+
+def _generate_qp(n: int) -> tuple[str, str]:
+    """Generate a random quadratic program with ``n`` variables."""
+    objective_terms = [f"{random.randint(1,5)}x{i}^2" for i in range(n)]
+    objective = " + ".join(objective_terms)
+    constraints = []
+    for j in range(n):
+        lhs = " + ".join(f"{random.randint(1,5)}x{i}" for i in range(n))
+        rhs = random.randint(n, 2 * n)
+        constraints.append(f"{lhs} >= {rhs}")
+    return objective, "\n".join(constraints)
+
+
+# Mapping problem types to named solver functions
+SOLVERS: Dict[str, Dict[str, Callable[[str, str], Tuple[str, float, Any]]]] = {
+    "linear_program": {
+        "pulp": _lp_with_pulp,
+        "cvxpy_ECOS_BB": lambda o, c: _lp_with_cvxpy(o, c, "ECOS_BB"),
+    },
+    "quadratic_program": {
+        "cvxpy_OSQP": lambda o, c: _qp_with_cvxpy(o, c, "OSQP"),
+        "cvxpy_ECOS": lambda o, c: _qp_with_cvxpy(o, c, "ECOS"),
+    },
+    "semidefinite_program": {
+        "cvxpy_SCS": lambda o, c: _generic_cvxpy(o, c, _sdp_problem, "SCS"),
+    },
+    "conic_program": {
+        "cvxpy_SCS": lambda o, c: _generic_cvxpy(o, c, _conic_problem, "SCS"),
+    },
+    "geometric_program": {
+        "cvxpy_SCS": lambda o, c: _generic_cvxpy(o, c, _gp_problem, "SCS", gp=True),
+    },
 }
 
 
-def run_benchmarks(output: str | None = None, *, return_results: bool = False):
-    problems = load_problems()
+def run_benchmarks(
+    output: str | None = None,
+    *,
+    return_results: bool = False,
+    size: int | None = None,
+    problem_type: str = "linear_program",
+    solver_filter: List[str] | None = None,
+    html_output: str | None = None,
+) -> List[dict] | None:
+    """Run benchmarks and optionally write results to files.
+
+    If ``size`` is provided, a random problem of ``problem_type`` is generated
+    with that many variables. Otherwise problems are loaded from the
+    ``problems`` directory.
+    """
+    if size is not None:
+        if problem_type == "linear_program":
+            obj, cons = _generate_lp(size)
+        elif problem_type == "quadratic_program":
+            obj, cons = _generate_qp(size)
+        else:
+            raise ValueError("Generated problems supported only for LP or QP")
+        problems = [
+            {
+                "name": f"generated_{problem_type}_{size}",
+                "type": problem_type,
+                "objective": obj,
+                "constraints": cons.splitlines(),
+            }
+        ]
+    else:
+        problems = load_problems()
     results = []
     for prob in problems:
         ptype = prob.get("type")
         objective = prob.get("objective", "")
         constraints = "\n".join(prob.get("constraints", []))
-        solvers = SOLVERS.get(ptype, [])
-        for solver_fn in solvers:
+        solvers = SOLVERS.get(ptype, {})
+        for sname, solver_fn in solvers.items():
+            if solver_filter and sname not in solver_filter:
+                continue
             solver_name, runtime, iters = solver_fn(objective, constraints)
             results.append({
                 "problem": prob.get("name"),
@@ -249,15 +310,51 @@ def run_benchmarks(output: str | None = None, *, return_results: bool = False):
         print("problem,type,solver,runtime,iterations")
         for row in results:
             print(",".join(str(row[h]) for h in ["problem", "type", "solver", "runtime", "iterations"]))
+    if html_output:
+        env = Environment(loader=FileSystemLoader("templates"))
+        template = env.get_template("benchmark.html")
+        html = template.render(results=results)
+        with open(html_output, "w", encoding="utf-8") as f:
+            f.write(html)
     if return_results:
         return results
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Benchmark sample optimization problems")
+    parser = argparse.ArgumentParser(
+        description="Benchmark sample or generated optimization problems"
+    )
     parser.add_argument("--output", "-o", help="Write results to CSV file")
+    parser.add_argument(
+        "--size",
+        type=int,
+        help="Generate a random problem of this size instead of using samples",
+    )
+    parser.add_argument(
+        "--type",
+        choices=list(SOLVERS.keys()),
+        default="linear_program",
+        help="Problem type when generating problems",
+    )
+    parser.add_argument(
+        "--solvers",
+        help="Comma separated solver names to run",
+    )
+    parser.add_argument(
+        "--html",
+        help="Write HTML table to the specified file",
+    )
     args = parser.parse_args()
-    run_benchmarks(args.output)
+
+    solver_list = args.solvers.split(",") if args.solvers else None
+
+    run_benchmarks(
+        args.output,
+        size=args.size,
+        problem_type=args.type,
+        solver_filter=solver_list,
+        html_output=args.html,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend `benchmark.py` with random problem generation helpers
- allow specifying problem size, type and solvers via CLI
- output HTML results using existing template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68482faaa578832ab5501e296b7a01cc