### PR TITLE
Add cross term support in QP solver

### DIFF
--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -7,7 +7,7 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from solvers import solve_lp
+from solvers import solve_lp, solve_qp
 
 
 def test_solve_lp_creates_missing_variables():
@@ -25,6 +25,11 @@ def test_missing_var_multiple_constraints():
     assert "y" in values
 
 from solvers import solve_sdp, solve_conic, solve_geometric
+
+
+def test_solve_qp_with_cross_term():
+    result = solve_qp("x^2 + 2*x*y + y^2", "x >= 0\ny >= 0")
+    assert "Status: optimal" in result
 
 
 def test_solve_sdp_basic():


### PR DESCRIPTION
## Summary
- update quadratic solver to parse cross terms using sympy utilities
- include numpy and new parser imports
- add regression test with a quadratic program containing `x*y`

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68485e057c0c832a995161ca3cb8dc34